### PR TITLE
Fixed bytestring TypeError for Python 3

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -68,10 +68,10 @@ def getSoup(*args, **kwargs):
     r = requests.get(*args, **kwargs)
 
     # --- Fix errors in khinsider's HTML
-    removeRe = re.compile(b"^</td>\s*$", re.MULTILINE)
+    removeRe = re.compile(r"^</td>\s*$", re.MULTILINE)
     # ---
     
-    return BeautifulSoup(re.sub(removeRe, b'', r.content), 'html.parser')
+    return BeautifulSoup(re.sub(removeRe, '', r.content.decode()), 'html.parser')
 
 class NonexistentSoundtrackError(Exception):
     def __init__(self, ostName=""):

--- a/khinsider.py
+++ b/khinsider.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     def installModules(modules, verbose=True):
         for module in modules:
             if verbose:
-                print("Installing {}...".format(module[1]))
+                print("Installing {}...".format(module[1]).decode())
             install(module[1])
     def installRequiredModules(needed=None, verbose=True):
         needed = neededInstalls() if needed is None else needed
@@ -68,7 +68,7 @@ def getSoup(*args, **kwargs):
     r = requests.get(*args, **kwargs)
 
     # --- Fix errors in khinsider's HTML
-    removeRe = re.compile(r"^</td>\s*$", re.MULTILINE)
+    removeRe = re.compile(b"^</td>\s*$", re.MULTILINE)
     # ---
     
     return BeautifulSoup(re.sub(removeRe, b'', r.content), 'html.parser')
@@ -133,14 +133,14 @@ def downloadSong(songUrl, path, name="song", numTries=3, verbose=False):
     """Download a single song at `songUrl` to `path`."""
     if verbose:
         print("Downloading {}...".format(name).encode(
-            sys.stdout.encoding, 'replace'))
+            sys.stdout.encoding, 'replace').decode())
 
     tries = 0
     while tries < numTries:
         try:
             if tries and verbose:
                 print("Couldn't download {}. Trying again...".format(
-                    name).encode(sys.stdout.encoding, 'replace'))
+                    name).encode(sys.stdout.encoding, 'replace').decode())
             song = requests.get(songUrl)
             break
         except requests.ConnectionError:
@@ -148,7 +148,7 @@ def downloadSong(songUrl, path, name="song", numTries=3, verbose=False):
     else:
         if verbose:
             print("Couldn't download {}. Skipping over.".format(
-                name).encode(sys.stdout.encoding, 'replace'))
+                name).encode(sys.stdout.encoding, 'replace').decode())
         return
 
     try:
@@ -157,7 +157,7 @@ def downloadSong(songUrl, path, name="song", numTries=3, verbose=False):
     except IOError:
         if verbose:
             print("Couldn't save {}. Check your permissions.".format(
-                name).encode(sys.stdout.encoding, 'replace'))
+                name).encode(sys.stdout.encoding, 'replace').decode())
 
 def search(term):
     """Return a list of OST IDs for the search term `term`."""
@@ -204,7 +204,7 @@ if __name__ == '__main__':
             # I don't know, maybe in some crazy circumstance the encoding for
             # arguments doesn't match stdout's encoding.
             print("\nThe soundtrack \"{}\" does not seem to exist.".format(
-                ostName).encode(sys.stdout.encoding, 'replace'))
+                ostName).encode(sys.stdout.encoding, 'replace').decode())
 
             if searchResults: # aww yeah we gon' do some searchin'
                 print()


### PR DESCRIPTION
First, please excuse me if I make any mistakes. This is my first pull request.

I'm running `khinsider.py` on Arch Linux. Using Python 3.5.0, `python3 khinsider.py wii-sports-wii-` fails to finish successfully and gives the following `TypeError`:

```python
Getting song list...
Traceback (most recent call last):
  File "khinsider.py", line 226, in <module>
    doIt()
  File "khinsider.py", line 194, in doIt
    download(ostName, outPath, verbose=True)
  File "khinsider.py", line 129, in download
    songInfos = getSongList(ostName)
  File "khinsider.py", line 107, in getSongList
    songPageUrls = getSongPageUrlList(ostName)
  File "khinsider.py", line 97, in getSongPageUrlList
    soup = getOstSoup(ostName)
  File "khinsider.py", line 89, in getOstSoup
    soup = getSoup(url)
  File "khinsider.py", line 74, in getSoup
    return BeautifulSoup(re.sub(removeRe, b'', r.content), 'html.parser')
  File "/usr/lib/python3.5/re.py", line 182, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: cannot use a string pattern on a bytes-like object
```

However, when I switched to Python 2.7.10 and used the command `python2 khinsider.py wii-sports-wii-`, the program executed successfully and downloaded all of the music files.

To fix the error and make the program compatible with Python 3, I decoded the last  two arguments (`repl` and `string`) of the `re.sub` call on line 74.

A side effect occurred: all output would also become bytestrings in Python 3. To fix this, I added `.decode()` to every printed string in the script.

Both of these changes have no effect in Python 2. Now, the program runs successfully in both versions of Python.