### PR TITLE
Skip previous downloaded files from the album.

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -164,8 +164,18 @@ def download(ostName, path="", verbose=False):
     songInfos = getFileList(ostName)
     totalSongs = len(songInfos)
     for songNumber, (name, url) in enumerate(songInfos):
-        downloadSong(url, path, name, verbose=verbose,
-            songNumber=songNumber + 1, totalSongs=totalSongs)
+        if not os.path.isfile(path + '/' + name):   # if file does not exist
+            downloadSong(url, path, name, verbose=verbose,
+                songNumber=songNumber + 1, totalSongs=totalSongs)
+        else:
+            if verbose:
+                numberStr = ""
+                if songNumber is not None and totalSongs is not None:
+                    numberStr += str(songNumber+1).zfill(len(str(totalSongs)))
+                    numberStr += "/"
+                    numberStr += str(totalSongs)
+                    numberStr += ": "
+                print("File Exists {}{}... Skipped.".format(numberStr, name))
 def downloadSong(songUrl, path, name="song", numTries=3, verbose=False,
     songNumber=None, totalSongs=None):
     """Download a single song at `songUrl` to `path`."""


### PR DESCRIPTION
I download many albums regularly on slow internet connection, and sometimes the download process stops unexpectedly and the album will not be completely downloaded.
The downloaded files can be skipped for downloading by checking if they are present in the destination folder.
Hope it helps others too ;)
