### PR TITLE
+ Support for duplicate named tracks (still requires the user to rena…

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -167,7 +167,15 @@ def friendlyDownloadFile(file, path, name, index, total, verbose=False):
         str(total)
     )
     path = os.path.join(path, file.filename)
-    
+
+    # Necessary for sound tracks that have duplicate names. I.e., Etrian Odyssey OST
+    if os.path.exists(path):
+        duplicate = "_dup"
+        if verbose:
+            unicodePrint("File {} exists: Appending {} to path.".format(name, duplicate))
+        path = path + duplicate
+        name = name + duplicate
+
     if not os.path.exists(path):
         if verbose:
             unicodePrint("Downloading {}: {}...".format(numberStr, name))


### PR DESCRIPTION
A small modification to support downloading sound tracks with duplicate names.  

A few examples:
[Etrian Odyssey OST](https://downloads.khinsider.com/game-soundtracks/album/etrian-odyssey-original-soundtrack)
[Etrian Odyssey II OST](https://downloads.khinsider.com/game-soundtracks/album/etrian-odyssey-ii-heroes-of-lagaard-original-soundtrack)

This change still requires the user to modify the file afterwards, and multiple duplicate names aren't supported.
