### PR TITLE
Fix #36

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -361,7 +361,7 @@ class Song(object):
 
     @lazyProperty
     def files(self):
-        anchors = [p.find('a') for p in self._soup('p', string=re.compile(r'^\s*Click here to download'))]
+        anchors = [p for p in self._soup('a', href=re.compile("^http://23.237.126.42/ost"))]
         return [File(urljoin(self.url, a['href'])) for a in anchors]
 
 


### PR DESCRIPTION
The HTML looks like it has changed. I (think) all the URIs for each
song are hosted from "http://23.237.126.42/ost..." so instead of
scraping from the text "Click here to download as...", scrape from
the matching href attribute that starts with the URI starting as
listed above. Tested and seems to fix the issues. However not sure
if the songs may be hosted on another server, which would break
this fix.