### PR TITLE
Display Download Progress of Individual Tracks

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -319,8 +319,12 @@ class Soundtrack(object):
         if verbose and not self._isLoaded('songs'):
             print("Getting song list...")
         files = []
-        for song in self.songs:
+        songsCount = len(self.songs)
+        for (index, song) in enumerate(self.songs):
             files.append(getAppropriateFile(song, formatOrder))
+            if verbose:
+                print("\r{}/{}".format(index+1, songsCount), end="")
+        print()
         files.extend(self.images)
         totalFiles = len(files)
 


### PR DESCRIPTION
As stated and shown below:
![bdp](https://user-images.githubusercontent.com/42816933/117799104-a30cb900-b206-11eb-99a3-3b6ebd93997b.gif)

Partially addresses #56 
It can be reassuring (or frustrating) to see progress when dealing with large file sizes and/or slow connections.