### PR TITLE
fix(getSoup): add random user agent usage to requests.get()

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -12,6 +12,7 @@ import re
 import sys
 from functools import wraps
 from itertools import chain
+from fake_useragent import UserAgent
 
 try:
     from urllib.parse import unquote, urljoin, urlsplit
@@ -163,7 +164,10 @@ def lazyProperty(func):
 
 
 def getSoup(*args, **kwargs):
-    r = requests.get(*args, **kwargs)
+    ua = UserAgent()
+    headers = {'User-Agent': ua.random}
+
+    r = requests.get(*args, **kwargs, headers=headers)
     return toSoup(r)
 
 REMOVE_RE = re.compile(br"^</td>\s*$", re.MULTILINE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+beautifulsoup4==4.13.4
+certifi==2025.6.15
+charset-normalizer==3.4.2
+fake-useragent==2.2.0
+idna==3.10
+requests==2.32.4
+soupsieve==2.7
+typing_extensions==4.14.0
+urllib3==2.5.0


### PR DESCRIPTION
It seems khinsider.com is now blocking automatic requests to their servers. This adds a random user agent to the request through `fake_useragent` library.

Fixes #100
Fixes #101
Fixes #104
Fixes #105