### PR TITLE
Migrate to Python 3

### DIFF
--- a/khinsider.py
+++ b/khinsider.py
@@ -35,11 +35,14 @@ Report issues: https://github.com/obskyr/khinsider/issues
 import os
 import re
 import sys
+import math
+import time
+import shutil
 import argparse
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, List, Optional
+from typing import Generator, List, Optional, Callable
 import importlib.util
 from urllib.parse import unquote, urljoin
 from dataclasses import dataclass
@@ -277,7 +280,6 @@ def _soup_from_bytes(data: bytes) -> BeautifulSoup:
     with suppress_output():
         return BeautifulSoup(fixed, "html.parser")
 
-
 def extract_soundtrack_id(candidate: str) -> str:
     """Return a soundtrack ID from a user-supplied ID or album URL.
 
@@ -292,6 +294,173 @@ def extract_soundtrack_id(candidate: str) -> str:
     """
     m = _ALBUM_URL_RE.match(candidate.strip())
     return m.group(1) if m else candidate.strip()
+
+def _human_size(n: int) -> str:
+    """Return a human-readable size for bytes."""
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(n)
+    for u in units:
+        if size < 1024.0 or u == units[-1]:
+            return f"{size:.1f} {u}"
+        size /= 1024.0
+    return f"{size:.1f} TB"
+
+
+def _fmt_seconds(value: float) -> str:
+    """Return whole seconds with an 's' suffix (e.g., '62s')."""
+    return f"{int(max(0, math.ceil(value)))}s"
+
+class _ProgressBar:
+    """Simple progress bar with speed and ETA.
+
+    The bar renders to `sys.stdout` on TTYs using a single in-place line and
+    throttles updates to ~20 FPS. When the total size is unknown, it shows a
+    spinner with bytes transferred, transfer speed, and elapsed time. When the
+    total is known, it shows a filled bar, bytes done/total, percent, speed,
+    and ETA in seconds.
+
+    The instance is a callable: call it with the number of newly written bytes
+    to update the bar. Call :meth:`close` once per file to finalize output.
+
+    Attributes:
+      prefix: Text placed before the bar (typically a filename and index).
+      total: Total number of bytes expected, or None if unknown.
+      width: Character width of the bar body (inside the brackets).
+      n: Total number of bytes observed so far (monotonically increasing).
+      _start: Monotonic timestamp when the bar started (seconds).
+      _last_print: Monotonic timestamp of the last render (seconds).
+      _tty: True if `sys.stdout` is a TTY; disables rendering when False.
+      _last_len: Length of the last rendered line (used to clear leftovers).
+    """
+
+    def __init__(self, prefix: str, total: Optional[int], width: int = 28):
+        """Initialize a new progress bar.
+
+        Adjusts the prefix to fit the current terminal width, reserving space
+        for the bar and metrics. Rendering is automatically disabled when
+        `sys.stdout` is not a TTY.
+
+        Args:
+          prefix: Text to display before the bar (e.g., "[01/10] file.ext").
+          total: Expected total bytes for the transfer; None if unknown.
+          width: Width of the bar body (characters inside the brackets).
+        """
+        self.prefix = prefix
+        self.total = total
+        self.width = max(10, width)
+        self.n = 0
+        self._start = time.time()
+        self._last_print = 0.0
+        self._tty = sys.stdout.isatty()
+        self._last_len = 0
+
+        # Fit bar width to terminal if possible.
+        try:
+            cols = shutil.get_terminal_size(fallback=(80, 20)).columns
+        except Exception:
+            cols = 80
+        # Reserve room for metrics; trim prefix if needed.
+        reserve = 28 + self.width  # numbers + bar
+        if len(prefix) + 1 + reserve > cols:
+            trim_to = max(8, cols - reserve - 1)
+            if len(prefix) > trim_to:
+                self.prefix = prefix[: trim_to - 1] + "…"
+
+    def __call__(self, delta: int, total_hint: Optional[int] = None) -> None:
+        """Advance the bar by `delta` bytes and render if appropriate.
+
+        This method is typically used as a callback from the downloader. It
+        updates the internal byte count and triggers a redraw at most ~20 times
+        per second (or always on completion). If a `total_hint` is provided and
+        the bar was created with an unknown total, the hint is adopted.
+
+        Rendering is skipped when stdout is not a TTY, but counters are still
+        updated.
+
+        Args:
+          delta: Number of newly transferred bytes to add (non-negative).
+          total_hint: Optional total bytes discovered mid-transfer.
+
+        Raises:
+          ValueError: If `delta` is negative.
+        """
+        if total_hint and self.total is None:
+            self.total = total_hint
+        self.n += max(0, int(delta))
+
+        # Print at ~20 FPS max and on completion.
+        now = time.time()
+        if not self._tty:
+            return
+        if self.total is not None and self.n >= self.total:
+            self._render()
+            return
+        if now - self._last_print >= 0.05:
+            self._last_print = now
+            self._render()
+
+    def close(self) -> None:
+        """Finalize the bar and end the line.
+
+        Ensures a final render (useful for unknown totals), prints a newline so
+        subsequent output starts on a fresh line, and resets internal render
+        length bookkeeping.
+
+        This should be called exactly once per transfer that used the bar.
+        Calling it multiple times is harmless.
+        """
+        if self._tty:
+            self._render()
+            print("")  # newline
+            self._last_len = 0
+
+    def _render(self) -> None:
+        """Render the current bar state to stdout.
+
+        For known totals, shows a proportional bar, bytes done/total, percent,
+        speed (binary units per second), and ETA as whole seconds with an 's'
+        suffix. For unknown totals, shows a spinner with bytes done, speed, and
+        elapsed time as whole seconds prefixed with '+'.
+
+        The output is trimmed to the terminal width and padded with spaces to
+        overwrite any leftover characters from a longer previous render.
+
+        Args:
+          final: If True, forces a final render (e.g., at 100%) regardless of
+            throttle timing.
+        """
+        cols = shutil.get_terminal_size(fallback=(80, 20)).columns
+        elapsed = max(1e-9, time.time() - self._start)
+        speed = self.n / elapsed
+        speed_s = f"{_human_size(int(speed))}/s"
+
+        if self.total and self.total > 0:
+            pct = min(1.0, self.n / self.total)
+            filled = int(self.width * pct)
+            head = ">" if filled < self.width else ""
+            bar = "[" + "=" * filled + head + "." * (self.width - filled - len(head)) + "]"
+            done_s = _human_size(self.n)
+            total_s = _human_size(self.total)
+            remain = (self.total - self.n) / speed if speed > 0 else 0.0
+            eta_str = _fmt_seconds(remain)
+            line = (f"{self.prefix} {bar} {done_s}/{total_s} ({int(pct*100):3d}%) "
+                    f"{speed_s} ETA {eta_str}")
+        else:
+            spin = "|/-\\"
+            idx = int(time.time() * 10) % len(spin)
+            bar = f"[{spin[idx]}{' ' * (self.width - 1)}]"
+            done_s = _human_size(self.n)
+            elapsed_str = _fmt_seconds(elapsed)
+            line = f"{self.prefix} {bar} {done_s} {speed_s} +{elapsed_str}"
+
+        # Trim to terminal width
+        out = line[: max(0, cols - 1)]
+
+        # Clear any leftover chars from previous, longer render.
+        pad = " " * max(0, self._last_len - len(out))
+        print("\r" + out + pad, end="", flush=True)
+
+        self._last_len = len(out)
 
 
 # ------------------------------------------------------------------------------
@@ -318,21 +487,36 @@ class AudioFile:
         self.filename = unquote(Path(url).name)
         self.extension = Path(url).suffix.lstrip(".").lower()
 
-    def download(self, dest: Path) -> None:
+    def download(
+        self,
+        dest: Path,
+        progress: Optional[Callable[[int, Optional[int]], None]] = None,
+    ) -> None:
         """Stream the file to disk.
 
         Args:
             dest: Destination path.
+            progress: Optional callback receiving (delta_bytes, total_bytes).
 
         Raises:
             requests.RequestException: On network error.
         """
-        resp = self.session.get(self.url, stream=True, timeout=90)
+        resp = self.session.get(self.url, stream=True, timeout=30)
         resp.raise_for_status()
+        total: Optional[int] = None
+        length = resp.headers.get("Content-Length")
+        if length and length.isdigit():
+            total = int(length)
+
+        if progress:
+            progress(0, total)
+
         with dest.open("wb") as f:
             for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
                 if chunk:
                     f.write(chunk)
+                    if progress:
+                        progress(len(chunk), total)
 
 
 class Song:
@@ -551,13 +735,15 @@ class Soundtrack:
                     return f
         return song.files[0]
 
-    def _save_item(self,
-                   item: AudioFile,
-                   output_dir: Path,
-                   idx: int,
-                   total: int,
-                   pad: int,
-                   verbose: bool) -> bool:
+    def _save_item(
+        self,
+        item: AudioFile,
+        output_dir: Path,
+        idx: int,
+        total: int,
+        pad: int,
+        verbose: bool,
+    ) -> bool:
         """Download a single file with retry logic.
 
         Args:
@@ -574,20 +760,36 @@ class Soundtrack:
         dest = output_dir / sanitize_filename(item.filename)
         if dest.exists():
             if verbose:
-                print(f"Skipping existing: {dest.name}")
+                print(f"[{idx:0{pad}d}/{total}] Skipping existing: {dest.name}")
             return True
 
-        if verbose:
-            label = f"[{idx:0{pad}d}/{total}]"
-            print(f"{label} Downloading {dest.name}...")
+        label = f"[{idx:0{pad}d}/{total}] {dest.name}"
+
+        use_bar = verbose and sys.stdout.isatty()
+        bar: Optional[_ProgressBar] = _ProgressBar(prefix=label, total=None) if use_bar else None
+        if verbose and not use_bar:
+            print(f"{label} ...")
 
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                item.download(dest)
+                if bar:
+                    bar(0, None)
+                    item.download(dest, progress=bar)
+                    bar.close()
+                else:
+                    item.download(dest)
                 return True
             except requests.RequestException:
+                if bar:
+                    bar.close()  # ensure newline before retry message
                 if verbose and attempt < MAX_RETRIES:
                     print(f"Retry {attempt}/{MAX_RETRIES} for {dest.name}")
+                if bar:
+                    bar = _ProgressBar(prefix=label, total=None)
+            except Exception:
+                if bar:
+                    bar.close()
+                raise
         return False
 
 @dataclass(frozen=True)

--- a/khinsider.py
+++ b/khinsider.py
@@ -26,8 +26,8 @@ Options:
 Examples:
     Download Aquaplus Vocal Collection Vol. 4 in FLAC:
         python khinsider.py --format flac "aquaplus-vocal-collection-vol.4"
-    Download KH3 OST in FLAC or MP3, plus images:
-        python khinsider.py kh3-ost -f flac,mp3 -i -v
+    Download Minecraft OST in FLAC or MP3, plus images:
+        python khinsider.py minecraft -f flac,mp3 -i -v
 
 Report issues: https://github.com/obskyr/khinsider/issues
 """
@@ -150,7 +150,7 @@ def get_soup(url: str, session: requests.Session) -> BeautifulSoup:
         data = _INVALID_ENTITY_RE.sub(b"&amp;#\\1", data)
         return BeautifulSoup(data, "html.parser")
     except requests.RequestException as e:
-        raise NetworkError(f"Failed to fetch {url}: {e}") from e
+        raise NetworkError(f"Failed to fetch {url}: {str(e)}") from e
 
 
 # ------------------------------------------------------------------------------
@@ -340,7 +340,7 @@ class Soundtrack:
         """
         if self._soup is None:
             self._soup = get_soup(self.url, self.session)
-            if self._soup.find(text="No such album"):
+            if self._soup.find(string="No such album"):
                 raise InvalidSoundtrackError(f"Album not found: {self.id}")
         return self._soup
 
@@ -381,7 +381,7 @@ class Soundtrack:
             except Exception as e:
                 success = False
                 if verbose:
-                    print(f"Error downloading track {idx}: {e}", file=sys.stderr)
+                    print(f"Error downloading track {idx}: {str(e)}", file=sys.stderr)
 
         # Download images if requested
         if download_images:
@@ -394,7 +394,7 @@ class Soundtrack:
                 except Exception as e:
                     success = False
                     if verbose:
-                        print(f"Error downloading image {idx}: {e}", file=sys.stderr)
+                        print(f"Error downloading image {idx}: {str(e)}", file=sys.stderr)
 
         return success
 
@@ -519,10 +519,10 @@ def main() -> None:
         print("\nDownload cancelled by user.", file=sys.stderr)
         sys.exit(1)
     except ScriptError as e:
-        print(f"\nError: {e}", file=sys.stderr)
+        print(f"\nError: {str(e)}", file=sys.stderr)
         sys.exit(1)
     except Exception as e:
-        print(f"\nUnexpected error: {e}", file=sys.stderr)
+        print(f"\nUnexpected error: {str(e)}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/khinsider.py
+++ b/khinsider.py
@@ -1,61 +1,67 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-A script to download full soundtracks from KHInsider.
+"""Download full soundtracks from KHInsider.
 
-This script allows users to download entire music albums from KHInsider by 
+This script allows users to download entire music albums from KHInsider by
 specifying the album ID found in the website's URL. It supports multiple audio
-formats and includes error handling for network issues and invalid inputs.
+formats, optional album image download, and includes error handling for network
+issues and invalid inputs.
 
 Features:
-- Automatic directory creation with sanitized names
-- Format selection prioritization
-- Connection reuse for improved performance
-- Comprehensive error reporting
-
-Parameters:
-  soundtrack_id    Soundtrack ID from KHInsider URL (e.g. "minecraft", always the last string in the url: https://downloads.khinsider.com/game-soundtracks/album/minecraft <--)
-  -o, --output  Output directory (default: soundtrack name)
-  -f, --format  Preferred formats, comma-separated (e.g. "flac,mp3")
-  -v, --verbose Show detailed progress information
+  - Automatic directory creation with sanitized names
+  - Format selection prioritization
+  - Optional download of album images (e.g., cover art)
+  - Connection reuse for improved performance
+  - Comprehensive error reporting
 
 Usage:
-    python khinsider_downloader.py <soundtrack_id> [-o OUTPUT_DIR] [-f FORMATS] [-v]
+    python khinsider.py <soundtrack_id> [-o OUTPUT_DIR] [-f FORMATS] [-i] [-v]
+
+Options:
+  -o, --output    Output directory (default: sanitized album name)
+  -f, --format    Preferred formats, comma-separated (e.g. 'flac,mp3')
+  -i, --images    Download album images as well (e.g., cover art)
+  -v, --verbose   Show detailed progress output
 
 Examples:
-    Download aquaplus vocal collections volume 4 in flac:
-    >>> python khinsider_checkerberry.py --format flac "aquaplus-vocal-collection-vol.4"
-    
-    Download KH3 original soundtrack in MP3:
-    >>> python khinsider_checkerberry.py kh3-ost -f flac,mp3 -v
+    Download Aquaplus Vocal Collection Vol. 4 in FLAC:
+        python khinsider.py --format flac "aquaplus-vocal-collection-vol.4"
+    Download KH3 OST in FLAC or MP3, plus images:
+        python khinsider.py kh3-ost -f flac,mp3 -i -v
 
-.. codeauthor:: obskyr <contact@obskyr.io>
-.. modernized:: Checkerberry
+Report issues: https://github.com/obskyr/khinsider/issues
 """
 
-import argparse
 import os
 import re
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Optional, Generator
+from typing import Generator, List, Optional
 from urllib.parse import unquote, urljoin
 
+import argparse
 import requests
 from bs4 import BeautifulSoup
 
-# Precompiled regex patterns for HTML preprocessing
-PRE_TD_RE = re.compile(br"^</td>\s*$", flags=re.MULTILINE)
-INVALID_ENTITY_RE = re.compile(br"&#([^0-9x]|x[^0-9A-Fa-f])")
-FILENAME_INVALID_RE = re.compile(r'[<>:"/\\|?*]')
+# ------------------------------------------------------------------------------
+# Constants
+# ------------------------------------------------------------------------------
 
-BASE_URL = 'https://downloads.khinsider.com/'
-SCRIPT_NAME = Path(sys.argv[0]).name
-REPORT_URL = "https://github.com/obskyr/khinsider/issues"
+BASE_URL = "https://downloads.khinsider.com/"
 MAX_RETRIES = 3
-CHUNK_SIZE = 65536  # 64KB chunks for download streaming
+CHUNK_SIZE = 64 * 1024  # 64KB
+REPORT_URL = "https://github.com/obskyr/khinsider/issues"
 
+# Precompiled regex patterns
+_PRE_TD_RE = re.compile(br"^</td>\s*$", flags=re.MULTILINE)
+_INVALID_ENTITY_RE = re.compile(br"&#([^0-9x]|x[^0-9A-Fa-f])")
+_FILENAME_INVALID_RE = re.compile(r'[<>:"/\\|?*]')
+
+
+# ------------------------------------------------------------------------------
+# Exceptions
+# ------------------------------------------------------------------------------
 
 class ScriptError(Exception):
     """Base exception for script-specific errors."""
@@ -66,436 +72,418 @@ class NetworkError(ScriptError):
 
 
 class InvalidSoundtrackError(ScriptError):
-    """Raised when requested soundtrack doesn't exist or is unavailable."""
+    """Raised when the requested soundtrack doesn't exist or is unavailable."""
 
 
 class InvalidFormatError(ScriptError):
     """Raised when none of the requested audio formats are available."""
 
 
+# ------------------------------------------------------------------------------
+# Utility Functions
+# ------------------------------------------------------------------------------
+
 @contextmanager
 def suppress_output() -> Generator[None, None, None]:
-    """Context manager to suppress all stdout/stderr output.
-    
+    """Suppress stdout and stderr temporarily.
+
     Yields:
-        None: No value yielded, used for context management
+        None
     """
-    with open(os.devnull, 'w') as null:
-        original_stdout = sys.stdout
-        original_stderr = sys.stderr
-        sys.stdout = null
-        sys.stderr = null
+    with open(os.devnull, "w") as null:
+        orig_stdout, orig_stderr = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = null, null
         try:
             yield
         finally:
-            sys.stdout = original_stdout
-            sys.stderr = original_stderr
+            sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
 
 def sanitize_filename(name: str) -> str:
-    """Convert string to a valid filesystem filename.
-    
+    """Convert a string to a safe filesystem filename.
+
+    Invalid characters are replaced with hyphens, trailing spaces or dots are
+    removed, and Windows reserved names are suffixed with an underscore.
+
     Args:
-        name: Original filename to sanitize
-    
+        name: Original filename to sanitize.
+
     Returns:
-        Sanitized filename with invalid characters replaced
-    
-    Example:
+        Sanitized filename.
+
+    Examples:
         >>> sanitize_filename('A/B?C*.txt')
         'A-B-C-.txt'
     """
-    sanitized = FILENAME_INVALID_RE.sub('-', name).rstrip(' .')
-    reserved = {'', '.', '..', '~', 'CON', 'PRN', 'AUX', 'NUL'} | \
-        {f'COM{i}' for i in range(1, 10)} | \
-        {f'LPT{i}' for i in range(1, 10)}
-    
+    sanitized = _FILENAME_INVALID_RE.sub("-", name).rstrip(" .")
+    reserved = (
+        {"", ".", "..", "~", "CON", "PRN", "AUX", "NUL"}
+        | {f"COM{i}" for i in range(1, 10)}
+        | {f"LPT{i}" for i in range(1, 10)}
+    )
     if sanitized.upper() in reserved:
-        return f'{sanitized}_'
+        return f"{sanitized}_"
     return sanitized
 
 
 def get_soup(url: str, session: requests.Session) -> BeautifulSoup:
-    """Fetch and parse HTML content from URL using persistent session.
-    
+    """Fetch and parse HTML content from a URL using a persistent session.
+
+    Applies preprocessing to fix known HTML issues before parsing.
+
     Args:
-        url: URL to fetch content from
-        session: Requests session for connection reuse
-    
+        url: The URL to fetch.
+        session: Session object for HTTP requests.
+
     Returns:
-        BeautifulSoup object containing parsed HTML
-        
+        Parsed BeautifulSoup object.
+
     Raises:
-        NetworkError: If connection fails multiple times
+        NetworkError: If the request fails or returns a bad status.
     """
     try:
         with suppress_output():
             response = session.get(url, timeout=15)
             response.raise_for_status()
-            
-            # Preprocess HTML to fix common issues
-            content = response.content
-            content = PRE_TD_RE.sub(b'', content)
-            content = INVALID_ENTITY_RE.sub(b'&amp;#\\1', content)
-            
-            return BeautifulSoup(content, 'html.parser')
+        data = response.content
+        data = _PRE_TD_RE.sub(b"", data)
+        data = _INVALID_ENTITY_RE.sub(b"&amp;#\\1", data)
+        return BeautifulSoup(data, "html.parser")
     except requests.RequestException as e:
-        raise NetworkError(f"Network error: {e}") from e
+        raise NetworkError(f"Failed to fetch {url}: {e}") from e
 
 
-class Soundtrack:
-    """Represents a KHInsider soundtrack album with download capabilities.
-    
+# ------------------------------------------------------------------------------
+# Core Classes
+# ------------------------------------------------------------------------------
+
+
+class AudioFile:
+    """Metadata and download logic for a single file (audio or image).
+
+    Args:
+        url: Direct download URL.
+        session: Shared HTTP session.
+
     Attributes:
-        id (str): Soundtrack ID extracted from URL
-        url (str): Full URL to the album page
-        name (str): Sanitized official album name
-        formats (List[str]): Available audio formats (e.g., ['mp3', 'flac'])
-        songs (List[Song]): List of tracks in the album
-    
-    Example:
-        >>> with requests.Session() as session:
-        ...     ost = Soundtrack('kh2fm-soundtrack', session)
-        ...     print(ost.name)
-        Kingdom Hearts II FM Original Soundtrack
+        url: Download URL.
+        filename: Decoded filename from the URL.
+        extension: File extension (lowercase).
     """
-    
-    def __init__(self, soundtrack_id: str, session: requests.Session):
-        """Initialize soundtrack with ID and persistent session.
-        
-        Args:
-            soundtrack_id: Album ID from KHInsider URL
-            session: Shared requests session for HTTP connections
-        """
-        self.id = soundtrack_id
+
+    def __init__(self, url: str, session: requests.Session):
+        self.url = url
         self.session = session
-        self.url = urljoin(BASE_URL, f'game-soundtracks/album/{self.id}')
-        self._soup = None
-        self._name = None
-        self._formats = None
-        self._songs = None
+        self.filename = unquote(Path(url).name)
+        self.extension = Path(url).suffix.lstrip(".").lower()
+
+    def download(self, dest: Path) -> None:
+        """Stream the file to disk.
+
+        Args:
+            dest: Destination path.
+
+        Raises:
+            requests.RequestException: On network error.
+        """
+        resp = self.session.get(self.url, stream=True, timeout=30)
+        resp.raise_for_status()
+        with dest.open("wb") as f:
+            for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
+                if chunk:
+                    f.write(chunk)
+
+
+class Song:
+    """Represents a single track with multiple format options.
+
+    Args:
+        url: URL of the track detail page.
+        session: Shared HTTP session.
+    """
+
+    def __init__(self, url: str, session: requests.Session):
+        self.url = url
+        self.session = session
+        self._soup: Optional[BeautifulSoup] = None
+        self._name: Optional[str] = None
+        self._files: Optional[List[AudioFile]] = None
 
     @property
     def name(self) -> str:
-        """Get official soundtrack name with sanitization.
-        
-        Returns:
-            Safe-to-use filename string
-            
+        """Extract and sanitize the track name."""
+        if self._name is None:
+            soup = self._load_soup()
+            name_tag = soup.find_all("p")[2].find("b")
+            self._name = sanitize_filename(name_tag.get_text(strip=True))
+        return self._name
+
+    @property
+    def files(self) -> List[AudioFile]:
+        """List available audio format options."""
+        if self._files is None:
+            soup = self._load_soup()
+            pattern = re.compile(r"/(?:soundtracks|ost)/")
+            links = [a["href"] for a in soup.find_all("a", href=pattern)]
+            self._files = [
+                AudioFile(urljoin(self.url, link), self.session)
+                for link in links
+            ]
+        return self._files
+
+    def _load_soup(self) -> BeautifulSoup:
+        """Lazy-load and cache the BeautifulSoup for this track page.
+
         Raises:
-            InvalidSoundtrackError: If album page indicates missing content
+            InvalidSoundtrackError: If the page returns a 404-like title.
         """
-        if not self._name:
-            soup = self._get_content()
-            name_tag = soup.find('h2')
-            if not name_tag:
-                raise InvalidSoundtrackError(f"Invalid album page: {self.url}")
+        if self._soup is None:
+            self._soup = get_soup(self.url, self.session)
+            title_text = self._soup.find("title").get_text()
+            if "404" in title_text:
+                raise InvalidSoundtrackError(f"Track not found: {self.url}")
+        return self._soup
+
+
+class Soundtrack:
+    """Handles album metadata and bulk download operations.
+
+    Args:
+        soundtrack_id: Album ID from KHInsider URL.
+        session: Shared HTTP session.
+
+    Attributes:
+        id: Album identifier.
+        url: Full album page URL.
+    """
+
+    def __init__(self, soundtrack_id: str, session: requests.Session):
+        self.id = soundtrack_id
+        self.session = session
+        self.url = urljoin(BASE_URL, f"game-soundtracks/album/{self.id}")
+        self._soup: Optional[BeautifulSoup] = None
+        self._name: Optional[str] = None
+        self._formats: Optional[List[str]] = None
+        self._songs: Optional[List[Song]] = None
+        self._images: Optional[List[AudioFile]] = None
+
+    @property
+    def name(self) -> str:
+        """Get the official album name, sanitized for filesystem use.
+
+        Raises:
+            InvalidSoundtrackError: If the album page is invalid.
+        """
+        if self._name is None:
+            soup = self._get_page()
+            name_tag = soup.find("h2")
+            if name_tag is None:
+                raise InvalidSoundtrackError(f"Album page invalid: {self.url}")
             self._name = sanitize_filename(name_tag.get_text(strip=True))
         return self._name
 
     @property
     def formats(self) -> List[str]:
-        """Get available audio formats from album table headers.
-        
-        Returns:
-            List of lowercase format identifiers
-        """
-        if not self._formats:
-            soup = self._get_content()
-            table = soup.find('table', id='songlist')
-            if not table:
-                return ['mp3']  # Default to MP3 if no table found
-            
-            headers = [th.get_text(strip=True).lower() 
-                       for th in table.find_all('th')]
-            self._formats = [
-                h for h in headers 
-                if h not in {'track', 'song name', 'download', 'size'}
-            ] or ['mp3']
+        """List available audio formats (e.g., ['mp3', 'flac'])."""
+        if self._formats is None:
+            soup = self._get_page()
+            table = soup.find("table", id="songlist")
+            if table is None:
+                self._formats = ["mp3"]
+            else:
+                headers = [th.get_text(strip=True).lower()
+                           for th in table.find_all("th")]
+                self._formats = [
+                    h for h in headers
+                    if h not in {"track", "song name", "download", "size"}
+                ] or ["mp3"]
         return self._formats
 
     @property
-    def songs(self) -> List['Song']:
-        """Get list of Song objects from track links.
-        
-        Returns:
-            List of Song instances representing album tracks
-        """
-        if not self._songs:
-            soup = self._get_content()
-            table = soup.find('table', id='songlist')
-            links = [tr.find('a')['href'] 
-                     for tr in table.find_all('tr') if tr.find('a')]
+    def songs(self) -> List[Song]:
+        """List Song objects for each track in the album."""
+        if self._songs is None:
+            soup = self._get_page()
+            table = soup.find("table", id="songlist")
+            links = [
+                tr.find("a")["href"]
+                for tr in table.find_all("tr")
+                if tr.find("a")
+            ]
             self._songs = [
-                Song(urljoin(self.url, link), self.session) 
+                Song(urljoin(self.url, link), self.session)
                 for link in links
             ]
         return self._songs
 
-    def _get_content(self) -> BeautifulSoup:
-        """Lazy-load and validate album page content.
-        
-        Returns:
-            Parsed BeautifulSoup object of album page
-            
+    @property
+    def images(self) -> List[AudioFile]:
+        """List album image files available for download."""
+        if self._images is None:
+            soup = self._get_page()
+            table = soup.find("table")
+            anchors = [
+                a for a in table.find_all("a")
+                if a.find("img")
+            ] if table else []
+            self._images = [
+                AudioFile(urljoin(self.url, a["href"]), self.session)
+                for a in anchors
+            ]
+        return self._images
+
+    def _get_page(self) -> BeautifulSoup:
+        """Lazy-load and validate the album page HTML.
+
         Raises:
-            InvalidSoundtrackError: If page contains error messages
+            InvalidSoundtrackError: If the album is not found.
         """
-        if not self._soup:
+        if self._soup is None:
             self._soup = get_soup(self.url, self.session)
-            error_text = self._soup.find("No such album")
-            if error_text:
-                raise InvalidSoundtrackError(f"Album {self.id} not found")
+            if self._soup.find(text="No such album"):
+                raise InvalidSoundtrackError(f"Album not found: {self.id}")
         return self._soup
 
-    def download(
-        self,
-        output_dir: Path,
-        formats: Optional[List[str]] = None,
-        verbose: bool = False
-    ) -> bool:
-        """Download complete soundtrack with format prioritization.
-        
+    def download(self,
+                 output_dir: Path,
+                 formats: Optional[List[str]] = None,
+                 download_images: bool = False,
+                 verbose: bool = False) -> bool:
+        """Download the entire soundtrack and optionally album images.
+
         Args:
-            output_dir: Target directory for downloaded files
-            formats: Preferred formats in descending priority order
-            verbose: Enable detailed progress output
-            
+            output_dir: Directory to save tracks (and images) into.
+            formats: Preferred audio formats in priority order.
+            download_images: If True, also download album images.
+            verbose: If True, show per-file progress.
+
         Returns:
-            True if all tracks downloaded successfully
-            
+            True if all requested files downloaded successfully.
+
         Raises:
-            InvalidFormatError: If no requested formats are available
-            OSError: If directory creation fails
+            InvalidFormatError: If no requested audio formats are available.
+            OSError: If output directory creation fails.
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         if formats and not set(formats).intersection(self.formats):
-            raise InvalidFormatError(
-                f"Available formats: {', '.join(self.formats)}"
-            )
+            raise InvalidFormatError(f"Available formats: {', '.join(self.formats)}")
 
+        total_tracks = len(self.songs)
+        pad_tracks = len(str(total_tracks))
         success = True
-        total = len(self.songs)
-        pad = len(str(total))
 
-        for idx, song in enumerate(self.songs, 1):
+        # Download audio tracks
+        for idx, song in enumerate(self.songs, start=1):
             try:
-                file = self._select_best_file(song, formats or [])
-                if not self._download_file(
-                    file, 
-                    output_dir,
-                    idx,
-                    total,
-                    pad,
-                    verbose
-                ):
+                chosen = self._select_best(song, formats or [])
+                if not self._save_item(chosen, output_dir, idx, total_tracks, pad_tracks, verbose):
                     success = False
             except Exception as e:
-                if verbose:
-                    print(f"Error downloading song {idx}: {e}", file=sys.stderr)
                 success = False
+                if verbose:
+                    print(f"Error downloading track {idx}: {e}", file=sys.stderr)
+
+        # Download images if requested
+        if download_images:
+            total_imgs = len(self.images)
+            pad_imgs = len(str(total_imgs))
+            for idx, img in enumerate(self.images, start=1):
+                try:
+                    if not self._save_item(img, output_dir, idx, total_imgs, pad_imgs, verbose):
+                        success = False
+                except Exception as e:
+                    success = False
+                    if verbose:
+                        print(f"Error downloading image {idx}: {e}", file=sys.stderr)
 
         return success
 
-    def _select_best_file(self, song: 'Song', formats: List[str]) -> 'AudioFile':
-        """Select highest priority available format for a track.
-        
-        Args:
-            song: Track to select format from
-            formats: Ordered list of preferred formats
-            
-        Returns:
-            Best matching AudioFile instance
-        """
-        if not formats:
+    def _select_best(self, song: Song, prefs: List[str]) -> AudioFile:
+        """Choose the highest-priority available AudioFile for a song."""
+        if not prefs:
             return song.files[0]
-            
-        for fmt in formats:
-            fmt_lower = fmt.lower()
-            for file in song.files:
-                if file.extension == fmt_lower:
-                    return file
+        for fmt in prefs:
+            for f in song.files:
+                if f.extension == fmt.lower():
+                    return f
         return song.files[0]
 
-    def _download_file(
-        self,
-        file: 'AudioFile',
-        output_dir: Path,
-        current: int,
-        total: int,
-        pad: int,
-        verbose: bool
-    ) -> bool:
-        """Download individual track with retry logic.
-        
+    def _save_item(self,
+                   item: AudioFile,
+                   output_dir: Path,
+                   idx: int,
+                   total: int,
+                   pad: int,
+                   verbose: bool) -> bool:
+        """Download a single file with retry logic.
+
         Args:
-            file: AudioFile to download
-            output_dir: Target directory
-            current: Current track number
-            total: Total tracks to download
-            pad: String padding for progress display
-            verbose: Enable status output
-            
+            item: AudioFile object to download.
+            output_dir: Destination directory.
+            idx: Index of this file in its category.
+            total: Total number of files in its category.
+            pad: Width for zero-padding progress numbers.
+            verbose: If True, print progress messages.
+
         Returns:
-            True if download succeeded
+            True if download succeeded or was skipped.
         """
-        dest = output_dir / sanitize_filename(file.filename)
+        dest = output_dir / sanitize_filename(item.filename)
         if dest.exists():
             if verbose:
                 print(f"Skipping existing: {dest.name}")
             return True
 
         if verbose:
-            progress = f"[{current:0{pad}d}/{total}]"
-            print(f"{progress} Downloading {dest.name}...")
+            label = f"[{idx:0{pad}d}/{total}]"
+            print(f"{label} Downloading {dest.name}...")
 
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                file.download(dest)
+                item.download(dest)
                 return True
-            except requests.RequestException as e:
+            except requests.RequestException:
                 if verbose and attempt < MAX_RETRIES:
                     print(f"Retry {attempt}/{MAX_RETRIES} for {dest.name}")
         return False
 
 
-class Song:
-    """Represents a single track with multiple audio format options.
-    
-    Attributes:
-        url (str): URL of track's detail page
-        name (str): Sanitized track name
-        files (List[AudioFile]): Available audio format options
-    """
-    
-    def __init__(self, url: str, session: requests.Session):
-        """Initialize track with URL and shared session.
-        
-        Args:
-            url: Full URL to track's page
-            session: Reusable requests session
-        """
-        self.url = url
-        self.session = session
-        self._soup = None
-        self._name = None
-        self._files = None
+# ------------------------------------------------------------------------------
+# Main Entry Point
+# ------------------------------------------------------------------------------
 
-    @property
-    def name(self) -> str:
-        """Extract and sanitize track name from page content."""
-        if not self._name:
-            soup = self._get_soup()
-            name_tag = soup.find_all('p')[2].find('b')
-            self._name = sanitize_filename(name_tag.get_text(strip=True))
-        return self._name
-
-    @property
-    def files(self) -> List['AudioFile']:
-        """Extract available audio file links from page."""
-        if not self._files:
-            soup = self._get_soup()
-            pattern = re.compile(r'/(?:soundtracks|ost)/')
-            links = [a['href'] for a in soup.find_all('a', href=pattern)]
-            self._files = [
-                AudioFile(urljoin(self.url, link), self.session) 
-                for link in links
-            ]
-        return self._files
-
-    def _get_soup(self) -> BeautifulSoup:
-        """Fetch and validate track page content."""
-        if not self._soup:
-            self._soup = get_soup(self.url, self.session)
-            if '404' in self._soup.find('title').text:
-                raise InvalidSoundtrackError(f"Invalid track URL: {self.url}")
-        return self._soup
-
-
-class AudioFile:
-    """Represents a downloadable audio file with metadata.
-    
-    Attributes:
-        url (str): Direct download URL
-        filename (str): Original filename from URL
-        extension (str): Lowercase file extension
-    """
-    
-    def __init__(self, url: str, session: requests.Session):
-        """Initialize with download URL and session.
-        
-        Args:
-            url: Direct download URL
-            session: Shared requests session
-        """
-        self.url = url
-        self.session = session
-        self.filename = unquote(Path(url).name)
-        self.extension = Path(url).suffix[1:].lower()
-
-    def download(self, dest: Path) -> None:
-        """Stream file to disk with large chunk size.
-        
-        Args:
-            dest: Path to save file
-            
-        Raises:
-            requests.RequestException: For network errors
-        """
-        response = self.session.get(self.url, stream=True, timeout=30)
-        response.raise_for_status()
-        
-        with dest.open('wb') as f:
-            for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
-                if chunk:  # Filter out keep-alive chunks
-                    f.write(chunk)
-
-
-def main():
-    """
-    Command-line interface for KHInsider soundtrack downloads.
-
-    This script now spoofs a Chrome browser User-Agent and sets a Referer header
-    to avoid 403 Forbidden errors when fetching pages from KHInsider.
-
-    Usage:
-        python khinsider_checkerberry.py <soundtrack_id> [-o OUTPUT_DIR] [-f FORMATS] [-v]
-
-    Positional arguments:
-      soundtrack           Album ID from KHInsider URL
-                           (e.g. 'kh2fm-soundtrack' from
-                           https://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)
-
-    Optional arguments:
-      -o, --output         Output directory (default: album name)
-      -f, --format         Preferred formats, comma-separated (e.g. 'flac,mp3')
-      -v, --verbose        Show detailed progress output
-    """
+def main() -> None:
+    """Parse CLI args, configure session, and download the soundtrack."""
     parser = argparse.ArgumentParser(
         description="Download KHInsider soundtracks (spoofing Chrome UA)",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=f"Report issues: {REPORT_URL}"
     )
     parser.add_argument(
-        'soundtrack',
+        "soundtrack",
         help=(
             "Album ID from KHInsider URL\n"
-            "(e.g. 'kh2fm-soundtrack' from\n"
+            "(e.g. 'kh2fm-soundtrack' from "
             "https://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)"
         )
     )
     parser.add_argument(
-        '-o', '--output',
+        "-o", "--output",
         type=Path,
         help="Output directory (default: album name)"
     )
     parser.add_argument(
-        '-f', '--format',
-        help="Preferred formats, comma-separated (e.g. 'flac,mp3')"
+        "-f", "--format",
+        help="Preferred audio formats, comma-separated (e.g. 'flac,mp3')"
     )
     parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
+        "-i", "--images",
+        action="store_true",
+        help="Download album images as well (e.g., cover art)"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
         help="Show detailed progress output"
     )
 
@@ -503,85 +491,40 @@ def main():
 
     try:
         with requests.Session() as session:
-            session.headers.update({ # Spoof Chrome and set Referer
-                'User-Agent': (
-                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                    'AppleWebKit/537.36 (KHTML, like Gecko) '
-                    'Chrome/114.0.0.0 Safari/537.36'
+            session.headers.update({
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/114.0.0.0 Safari/537.36"
                 ),
-                'Referer': 'https://downloads.khinsider.com/'
+                "Referer": BASE_URL
             })
 
             ost = Soundtrack(args.soundtrack, session)
-            output_dir = args.output or Path(sanitize_filename(ost.name))
+            out_dir = args.output or Path(sanitize_filename(ost.name))
 
             if ost.download(
-                output_dir=output_dir,
-                formats=args.format.split(',') if args.format else None,
+                output_dir=out_dir,
+                formats=args.format.split(",") if args.format else None,
+                download_images=args.images,
                 verbose=args.verbose
             ):
                 print("\nDownload completed successfully!")
                 sys.exit(0)
-
-            print("\nDownload completed with errors!", file=sys.stderr)
-            sys.exit(1)
+            else:
+                print("\nDownload completed with some errors.", file=sys.stderr)
+                sys.exit(1)
 
     except KeyboardInterrupt:
-        print("\nDownload cancelled.", file=sys.stderr)
+        print("\nDownload cancelled by user.", file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
+    except ScriptError as e:
         print(f"\nError: {e}", file=sys.stderr)
         sys.exit(1)
-
-    """Command-line interface for soundtrack downloads."""
-    parser = argparse.ArgumentParser(
-        description="Download KHInsider soundtracks",
-        formatter_class=argparse.RawTextHelpFormatter,
-        epilog=f"Report issues: {REPORT_URL}"
-    )
-    parser.add_argument(
-        'soundtrack',
-        help="Album ID from KHInsider URL\n(e.g. 'kh2fm-soundtrack' from\nhttps://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)"
-    )
-    parser.add_argument(
-        '-o', '--output',
-        type=Path,
-        help="Output directory (default: album name)"
-    )
-    parser.add_argument(
-        '-f', '--format',
-        help="Preferred formats, comma-separated\n(e.g. 'flac,mp3')"
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        help="Show detailed progress output"
-    )
-    
-    args = parser.parse_args()
-    
-    try:
-        with requests.Session() as session:
-            ost = Soundtrack(args.soundtrack, session)
-            output_dir = args.output or Path(sanitize_filename(ost.name))
-            
-            if ost.download(
-                output_dir=output_dir,
-                formats=args.format.split(',') if args.format else None,
-                verbose=args.verbose
-            ):
-                print("\nDownload completed successfully!")
-                sys.exit(0)
-            print("\nDownload completed with errors!", file=sys.stderr)
-            sys.exit(1)
-            
-    except KeyboardInterrupt:
-        print("\nDownload cancelled.", file=sys.stderr)
-        sys.exit(1)
     except Exception as e:
-        print(f"\nError: {e}", file=sys.stderr)
+        print(f"\nUnexpected error: {e}", file=sys.stderr)
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/khinsider.py
+++ b/khinsider.py
@@ -20,14 +20,14 @@ Usage:
 Options:
   -o, --output    Output directory (default: sanitized album name)
   -f, --format    Preferred formats, comma-separated (e.g. 'flac,mp3')
-  -i, --images    Download album images as well (e.g., cover art)
-  -v, --verbose   Show detailed progress output
+  -i, --images    Download album images (default: enabled; use --no-images to disable)
+  -v, --verbose   Show detailed progress (default: enabled; use --no-verbose to disable)
 
 Examples:
     Download Aquaplus Vocal Collection Vol. 4 in FLAC:
         python khinsider.py --format flac "aquaplus-vocal-collection-vol.4"
     Download Minecraft OST in FLAC or MP3, plus images:
-        python khinsider.py minecraft -f flac,mp3 -i -v
+        python khinsider.py https://downloads.khinsider.com/game-soundtracks/album/minecraft -f flac,mp3 -i -v
 
 Report issues: https://github.com/obskyr/khinsider/issues
 """
@@ -35,14 +35,109 @@ Report issues: https://github.com/obskyr/khinsider/issues
 import os
 import re
 import sys
+import argparse
+import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, List, Optional
+import importlib.util
 from urllib.parse import unquote, urljoin
+from dataclasses import dataclass
+from urllib.parse import urlsplit
 
-import argparse
+
+# ------------------------------------------------------------------------------
+# Dependency bootstrap
+# ------------------------------------------------------------------------------
+
+_REQUIRED_PKGS = {
+    "requests": "requests>=2.0,<3.0",
+    "bs4": "beautifulsoup4>=4.4,<5.0",
+}
+
+
+def _in_venv() -> bool:
+    """Return True if running inside a virtual environment."""
+    base = getattr(sys, "base_prefix", sys.prefix)
+    return sys.prefix != base or hasattr(sys, "real_prefix")
+
+
+def _ensure_pip_available(verbose: bool = False) -> None:
+    """Ensure 'pip' is importable for 'python -m pip' invocations."""
+    try:
+        import pip  # noqa: F401  # pylint: disable=unused-import
+        return
+    except Exception:
+        pass
+
+    try:
+        import ensurepip  # type: ignore  # noqa: F401
+    except Exception as exc:
+        # Use RuntimeError here to avoid depending on later exception classes.
+        raise RuntimeError(
+            "pip is not available and the standard library 'ensurepip' module "
+            "could not be imported to bootstrap it."
+        ) from exc
+
+    if verbose:
+        print("Bootstrapping pip via ensurepip...", file=sys.stderr)
+    subprocess.check_call(
+        [sys.executable, "-m", "ensurepip", "--upgrade"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _install_with_pip(specs: List[str], verbose: bool = True) -> None:
+    """Install the given requirement specs using pip.
+
+    Uses --user when not in a virtualenv to avoid admin rights.
+    """
+    env = os.environ.copy()
+    env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
+
+    cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]
+    if not _in_venv():
+        cmd.append("--user")
+    cmd.extend(specs)
+
+    if verbose:
+        print("Installing required packages: " + ", ".join(specs), file=sys.stderr)
+
+    try:
+        subprocess.check_call(
+            cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "Automatic dependency installation failed. "
+            "Install manually:\n  " + " ".join(cmd)
+        ) from exc
+
+
+def _ensure_runtime_dependencies(verbose: bool = True) -> None:
+    """Ensure third-party dependencies exist; auto-install if missing.
+
+    KHI_NO_AUTO_INSTALL=1 to skip auto-install.
+    """
+    if os.environ.get("KHI_NO_AUTO_INSTALL") == "1":
+        return
+
+    missing = [name for name in _REQUIRED_PKGS if importlib.util.find_spec(name) is None]
+    if not missing:
+        return
+
+    _ensure_pip_available(verbose=verbose)
+    specs = [_REQUIRED_PKGS[name] for name in missing]
+    _install_with_pip(specs, verbose=verbose)
+
+
+# Call the bootstrap BEFORE third-party imports.
+_ensure_runtime_dependencies(verbose=True)
+
 import requests
 from bs4 import BeautifulSoup
+
 
 # ------------------------------------------------------------------------------
 # Constants
@@ -78,6 +173,9 @@ class InvalidSoundtrackError(ScriptError):
 class InvalidFormatError(ScriptError):
     """Raised when none of the requested audio formats are available."""
 
+class SearchError(ScriptError):
+    """Raised when a search operation cannot return results."""
+
 
 # ------------------------------------------------------------------------------
 # Utility Functions
@@ -98,6 +196,19 @@ def suppress_output() -> Generator[None, None, None]:
         finally:
             sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
+_ALBUM_URL_RE = re.compile(
+    r"^https?://(?:www\.)?downloads\.khinsider\.com/"
+    r"game-soundtracks/album/([^/?#]+)(?:/)?$",
+    flags=re.IGNORECASE,
+)
+
+def _extract_id_and_url(value: str) -> tuple[str, Optional[str]]:
+    """Return (album_id, full_url_if_given_or_None) from user input."""
+    value = value.strip()
+    m = _ALBUM_URL_RE.match(value)
+    if m:
+        return m.group(1), value  # (id, full_url)
+    return value, None
 
 def sanitize_filename(name: str) -> str:
     """Convert a string to a safe filesystem filename.
@@ -143,7 +254,7 @@ def get_soup(url: str, session: requests.Session) -> BeautifulSoup:
     """
     try:
         with suppress_output():
-            response = session.get(url, timeout=15)
+            response = session.get(url, timeout=30)
             response.raise_for_status()
         data = response.content
         data = _PRE_TD_RE.sub(b"", data)
@@ -151,6 +262,36 @@ def get_soup(url: str, session: requests.Session) -> BeautifulSoup:
         return BeautifulSoup(data, "html.parser")
     except requests.RequestException as e:
         raise NetworkError(f"Failed to fetch {url}: {str(e)}") from e
+
+def _soup_from_bytes(data: bytes) -> BeautifulSoup:
+    """Parse HTML bytes into BeautifulSoup after KHInsider-specific fixes.
+
+    Args:
+        data: Raw response content.
+
+    Returns:
+        Parsed BeautifulSoup object.
+    """
+    fixed = _PRE_TD_RE.sub(b"", data)
+    fixed = _INVALID_ENTITY_RE.sub(b"&amp;#\\1", fixed)
+    with suppress_output():
+        return BeautifulSoup(fixed, "html.parser")
+
+
+def extract_soundtrack_id(candidate: str) -> str:
+    """Return a soundtrack ID from a user-supplied ID or album URL.
+
+    If the string looks like a full KHInsider album URL, the final path segment
+    is extracted; otherwise it is returned as-is.
+
+    Args:
+        candidate: ID or album URL.
+
+    Returns:
+        The soundtrack ID.
+    """
+    m = _ALBUM_URL_RE.match(candidate.strip())
+    return m.group(1) if m else candidate.strip()
 
 
 # ------------------------------------------------------------------------------
@@ -186,7 +327,7 @@ class AudioFile:
         Raises:
             requests.RequestException: On network error.
         """
-        resp = self.session.get(self.url, stream=True, timeout=30)
+        resp = self.session.get(self.url, stream=True, timeout=90)
         resp.raise_for_status()
         with dest.open("wb") as f:
             for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
@@ -214,8 +355,8 @@ class Song:
         """Extract and sanitize the track name."""
         if self._name is None:
             soup = self._load_soup()
-            name_tag = soup.find_all("p")[2].find("b")
-            self._name = sanitize_filename(name_tag.get_text(strip=True))
+            name_tag = soup.find_all("p")[2].find("b")  # type: ignore
+            self._name = sanitize_filename(name_tag.get_text(strip=True))  # type: ignore
         return self._name
 
     @property
@@ -224,9 +365,9 @@ class Song:
         if self._files is None:
             soup = self._load_soup()
             pattern = re.compile(r"/(?:soundtracks|ost)/")
-            links = [a["href"] for a in soup.find_all("a", href=pattern)]
+            links = [a["href"] for a in soup.find_all("a", href=pattern)]  # type: ignore
             self._files = [
-                AudioFile(urljoin(self.url, link), self.session)
+                AudioFile(urljoin(self.url, link), self.session)  # type: ignore
                 for link in links
             ]
         return self._files
@@ -239,7 +380,7 @@ class Song:
         """
         if self._soup is None:
             self._soup = get_soup(self.url, self.session)
-            title_text = self._soup.find("title").get_text()
+            title_text = self._soup.find("title").get_text()  # type: ignore
             if "404" in title_text:
                 raise InvalidSoundtrackError(f"Track not found: {self.url}")
         return self._soup
@@ -258,9 +399,11 @@ class Soundtrack:
     """
 
     def __init__(self, soundtrack_id: str, session: requests.Session):
-        self.id = soundtrack_id
+        album_id, full_url = _extract_id_and_url(soundtrack_id)
+        self.id = album_id
         self.session = session
-        self.url = urljoin(BASE_URL, f"game-soundtracks/album/{self.id}")
+        # If the user passed a full album URL, use it verbatim. Otherwise build it.
+        self.url = full_url or urljoin(BASE_URL, f"game-soundtracks/album/{self.id}")
         self._soup: Optional[BeautifulSoup] = None
         self._name: Optional[str] = None
         self._formats: Optional[List[str]] = None
@@ -292,7 +435,7 @@ class Soundtrack:
                 self._formats = ["mp3"]
             else:
                 headers = [th.get_text(strip=True).lower()
-                           for th in table.find_all("th")]
+                           for th in table.find_all("th")]  # type: ignore
                 self._formats = [
                     h for h in headers
                     if h not in {"track", "song name", "download", "size"}
@@ -306,12 +449,12 @@ class Soundtrack:
             soup = self._get_page()
             table = soup.find("table", id="songlist")
             links = [
-                tr.find("a")["href"]
-                for tr in table.find_all("tr")
-                if tr.find("a")
+                tr.find("a")["href"]  # type: ignore
+                for tr in table.find_all("tr")  # type: ignore
+                if tr.find("a")  # type: ignore
             ]
             self._songs = [
-                Song(urljoin(self.url, link), self.session)
+                Song(urljoin(self.url, link), self.session)  # type: ignore
                 for link in links
             ]
         return self._songs
@@ -323,11 +466,11 @@ class Soundtrack:
             soup = self._get_page()
             table = soup.find("table")
             anchors = [
-                a for a in table.find_all("a")
-                if a.find("img")
+                a for a in table.find_all("a")  # type: ignore
+                if a.find("img")  # type: ignore
             ] if table else []
             self._images = [
-                AudioFile(urljoin(self.url, a["href"]), self.session)
+                AudioFile(urljoin(self.url, a["href"]), self.session)  # type: ignore
                 for a in anchors
             ]
         return self._images
@@ -447,6 +590,122 @@ class Soundtrack:
                     print(f"Retry {attempt}/{MAX_RETRIES} for {dest.name}")
         return False
 
+@dataclass(frozen=True)
+class SearchResults:
+    """Container for search results."""
+    albums: List["Soundtrack"]
+    songs: List["Soundtrack"]
+
+
+def search_soundtracks(term: str, session: requests.Session) -> SearchResults:
+    """Search KHInsider for albums and songs matching a term.
+
+    The search endpoint may redirect straight to an album page when there is
+    an exact match; handle that by returning a single-album result.
+
+    Args:
+        term: Free-text search term.
+        session: Shared HTTP session.
+
+    Returns:
+        SearchResults with albums and song-title matches.
+
+    Raises:
+        SearchError: If the search fails or returns no parsable results.
+        NetworkError: If the request itself fails.
+    """
+    try:
+        resp = session.get(
+            urljoin(BASE_URL, "search"),
+            params={"search": term},
+            timeout=30,
+            allow_redirects=True,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise NetworkError(f"Failed to search for '{term}': {str(e)}") from e
+
+    # If we were redirected directly to an album page, return that album.
+    path = urlsplit(resp.url).path
+    if path.startswith("/game-soundtracks/album/"):
+        ost_id = path.rstrip("/").rsplit("/", 1)[-1]
+        return SearchResults(albums=[Soundtrack(ost_id, session)], songs=[])
+
+    soup = _soup_from_bytes(resp.content)
+
+    tables = soup.find_all("table", class_="albumList")
+    if not tables:
+        # Typical page contains a <p> with a human message.
+        message_tag = soup.find("p")
+        message = message_tag.get_text(strip=True) if message_tag else ""
+        raise SearchError(message or "No results returned.")
+
+    def _parse_table(table: BeautifulSoup) -> List[Soundtrack]:
+        """Parse one albumList table into Soundtrack stubs.
+
+        We assign the discovered name directly to avoid extra requests when
+        printing results later.
+        """
+        rows = table.find_all("tr")[1:]  # skip header row
+        found: List[Soundtrack] = []
+        for tr in rows:
+            tds = tr.find_all("td")  # type: ignore
+            if len(tds) < 2:
+                continue
+            anchor = tds[1].find("a")  # type: ignore
+            if not anchor or not anchor.get("href"):  # type: ignore
+                continue
+            album_id = anchor["href"].rstrip("/").rsplit("/", 1)[-1]  # type: ignore
+            name_text = anchor.get_text(strip=True)  # type: ignore
+            ost = Soundtrack(album_id, session)
+            # Pre-populate the cached name to avoid fetching each album page.
+            ost._name = sanitize_filename(name_text)
+            found.append(ost)
+        return found
+
+    parsed_tables = [_parse_table(t) for t in tables]  # type: ignore
+    if len(parsed_tables) == 1:
+        # If the page wording says it's song results, keep it in songs.
+        page_p = soup.find(id="pageContent")
+        text = (page_p.find("p").get_text(strip=True)  # type: ignore
+                if page_p and page_p.find("p") else "")  # type: ignore
+        if "song" in text.lower():
+            return SearchResults(albums=[], songs=parsed_tables[0])
+        return SearchResults(albums=parsed_tables[0], songs=[])
+
+    # Two tables: first albums, second songs.
+    albums = parsed_tables[0]
+    songs = parsed_tables[1] if len(parsed_tables) > 1 else []
+    return SearchResults(albums=albums, songs=songs)
+
+
+def print_search_results(results: SearchResults, file=sys.stdout) -> None:
+    """Pretty-print search results, similar to the legacy script.
+
+    Args:
+        results: Search outcome to print.
+        file: Target stream (stdout or stderr).
+    """
+    all_items = results.albums + results.songs
+    if not all_items:
+        print("No soundtracks found.", file=file)
+        return
+
+    pad = max((len(ost.id) for ost in all_items), default=0)
+
+    def _print_group(title: str, items: List[Soundtrack]) -> None:
+        if not items:
+            return
+        print(title, file=file)
+        for ost in items:
+            dots = "." * (pad - len(ost.id) + 1)
+            # ost.name is often pre-populated; if not, it will fetch lazily.
+            print(f"{ost.id} {dots} {ost.name}", file=file)
+        print("", file=file)
+
+    _print_group("Album title results:", results.albums)
+    _print_group("Song name results:", results.songs)
+
 
 # ------------------------------------------------------------------------------
 # Main Entry Point
@@ -477,15 +736,29 @@ def main() -> None:
         help="Preferred audio formats, comma-separated (e.g. 'flac,mp3')"
     )
     parser.add_argument(
-        "-i", "--images",
-        action="store_true",
-        help="Download album images as well (e.g., cover art)"
+    "-i",
+    "--images",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Download album images (default: enabled; use --no-images to disable).",
     )
     parser.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        help="Show detailed progress output"
+    "-v",
+    "--verbose",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Show detailed progress (default: enabled; use --no-verbose to disable).",
     )
+    parser.add_argument(
+        "-s", "--search",
+        action="store_true",
+        help=(
+            "Search for soundtracks instead of downloading. "
+            "Also used automatically if the supplied soundtrack ID "
+            "does not exist."
+        ),
+    )
+    
 
     args = parser.parse_args()
 
@@ -497,22 +770,67 @@ def main() -> None:
                     "AppleWebKit/537.36 (KHTML, like Gecko) "
                     "Chrome/114.0.0.0 Safari/537.36"
                 ),
-                "Referer": BASE_URL
+                "Referer": BASE_URL,
             })
 
-            ost = Soundtrack(args.soundtrack, session)
-            out_dir = args.output or Path(sanitize_filename(ost.name))
+            # Normalize possible full album URL to an ID.
+            user_input = args.soundtrack
+            soundtrack_id = extract_soundtrack_id(user_input)
 
-            if ost.download(
-                output_dir=out_dir,
-                formats=args.format.split(",") if args.format else None,
-                download_images=args.images,
-                verbose=args.verbose
-            ):
-                print("\nDownload completed successfully!")
+            # If explicitly asked to search, do that and exit.
+            if args.search:
+                try:
+                    results = search_soundtracks(user_input, session)
+                except (SearchError, NetworkError) as e:
+                    print(f"Search failed: {e}", file=sys.stderr)
+                    sys.exit(1)
+                print(
+                    "Soundtracks found (to download, run "
+                    '"python khinsider.py <soundtrack_id>"):\n'
+                )
+                print_search_results(results)
                 sys.exit(0)
-            else:
+
+            # Otherwise, attempt normal download; on missing album, fall back to
+            # an automatic search using a friendlier term.
+            try:
+                ost = Soundtrack(soundtrack_id, session)
+                out_dir = args.output or Path(sanitize_filename(ost.name))
+
+                ok = ost.download(
+                    output_dir=out_dir,
+                    formats=args.format.split(",") if args.format else None,
+                    download_images=args.images,
+                    verbose=args.verbose,
+                )
+                if ok:
+                    print("\nDownload completed successfully!")
+                    sys.exit(0)
                 print("\nDownload completed with some errors.", file=sys.stderr)
+                sys.exit(1)
+
+            except InvalidSoundtrackError:
+                # Friendly automatic search, similar to legacy behavior.
+                search_term = user_input.replace("-", " ")
+                try:
+                    results = search_soundtracks(search_term, session)
+                except (SearchError, NetworkError):
+                    print(
+                        f'The soundtrack "{soundtrack_id}" does not seem to exist, '
+                        "and a search could not be performed.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+
+                print(
+                    f'The soundtrack "{soundtrack_id}" does not seem to exist.\n',
+                    file=sys.stderr,
+                )
+                print(
+                    'These exist, though (run "python khinsider.py <soundtrack_id>"):',
+                    file=sys.stderr,
+                )
+                print_search_results(results, file=sys.stderr)
                 sys.exit(1)
 
     except KeyboardInterrupt:

--- a/khinsider.py
+++ b/khinsider.py
@@ -1,681 +1,587 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""
+A script to download full soundtracks from KHInsider.
 
-# A script to download full soundtracks from KHInsider.
+This script allows users to download entire music albums from KHInsider by 
+specifying the album ID found in the website's URL. It supports multiple audio
+formats and includes error handling for network issues and invalid inputs.
 
-# __future__ import for forwards compatibility with Python 3
-from __future__ import print_function
-from __future__ import unicode_literals
+Features:
+- Automatic directory creation with sanitized names
+- Format selection prioritization
+- Connection reuse for improved performance
+- Comprehensive error reporting
 
+Parameters:
+  soundtrack_id    Soundtrack ID from KHInsider URL (e.g. "minecraft", always the last string in the url: https://downloads.khinsider.com/game-soundtracks/album/minecraft <--)
+  -o, --output  Output directory (default: soundtrack name)
+  -f, --format  Preferred formats, comma-separated (e.g. "flac,mp3")
+  -v, --verbose Show detailed progress information
+
+Usage:
+    python khinsider_downloader.py <soundtrack_id> [-o OUTPUT_DIR] [-f FORMATS] [-v]
+
+Examples:
+    Download aquaplus vocal collections volume 4 in flac:
+    >>> python khinsider_checkerberry.py --format flac "aquaplus-vocal-collection-vol.4"
+    
+    Download KH3 original soundtrack in MP3:
+    >>> python khinsider_checkerberry.py kh3-ost -f flac,mp3 -v
+
+.. codeauthor:: obskyr <contact@obskyr.io>
+.. modernized:: Checkerberry
+"""
+
+import argparse
 import os
 import re
 import sys
-from functools import wraps
-from itertools import chain
-
-try:
-    from urllib.parse import unquote, urljoin, urlsplit
-except ImportError: # Python 2
-    from urlparse import unquote, urljoin, urlsplit
-
-try: # Python 2
-    from os import getcwdu as getcwd
-except ImportError:
-    from os import getcwd
-
-class Silence(object):
-    def __enter__(self):
-        self._stdout = sys.stdout
-        self._stderr = sys.stderr
-        sys.stdout = open(os.devnull, 'w')
-        sys.stderr = open(os.devnull, 'w')
-    
-    def __exit__(self, *_):
-        sys.stdout = self._stdout
-        sys.stderr = self._stderr
-
-
-# --- Install prerequisites ---
-
-# (This section in `if __name__ == '__main__':` is entirely unrelated to the
-# rest of the module, and doesn't even run if the module isn't run by itself.)
-
-if __name__ == '__main__':
-    # To check for the existence of modules without importing them.
-    # Apparently imp and importlib are a forest of deprecation!
-    # The API was changed once in 3.3 (deprecating imp),
-    # and then again in 3.4 (deprecating the 3.3 API).
-    # So.... we have to do this dance to avoid deprecation warnings.
-    try:
-        try:
-            from importlib.util import find_spec as find_module # Python 3.4+
-        except ImportError:
-            from importlib import find_loader as find_module # Python 3.3
-    except ImportError:
-        from imp import find_module # Python 2
-
-    # User-friendly name, import name, pip specification.
-    requiredModules = [
-        ['requests', 'requests', 'requests >= 2.0.0, < 3.0.0'],
-        ['Beautiful Soup 4', 'bs4', 'beautifulsoup4 >= 4.4.0, < 5.0.0']
-    ]
-
-    def moduleExists(name):
-        try:
-            result = find_module(name)
-        except ImportError:
-            return False
-        else:
-            return result is not None
-    def neededInstalls(requiredModules=requiredModules):
-        uninstalledModules = []
-        for module in requiredModules:
-            if not moduleExists(module[1]):
-                uninstalledModules.append(module)
-        return uninstalledModules
-
-    def install(package):
-        nowhere = open(os.devnull, 'w')
-        exitStatus = subprocess.call([sys.executable, '-m', 'pip', 'install', package],
-                                     stdout=nowhere,
-                                     stderr=nowhere)
-        if exitStatus != 0:
-            raise OSError("Failed to install package.")
-    def installModules(modules, verbose=True):
-        for module in modules:
-            if verbose:
-                print("Installing {}...".format(module[0]))
-            
-            try:
-                install(module[2])
-            except OSError as e:
-                if verbose:
-                    print("Failed to install {}. "
-                          "You may need to run the script as an administrator "
-                          "or superuser.".format(module[0]),
-                          file=sys.stderr)
-                    print("You can also try to install the package manually "
-                          "(pip install \"{}\")".format(module[2]),
-                          file=sys.stderr)
-                raise e
-    def installRequiredModules(needed=None, verbose=True):
-        needed = neededInstalls() if needed is None else needed
-        installModules(neededInstalls(), verbose)
-
-    needed = neededInstalls()
-    if needed:
-        if moduleExists('pip'):
-            # Needed to call pip the official way.
-            import subprocess
-        else:
-            print("You don't seem to have pip installed!", file=sys.stderr)
-            print("Get it from https://pip.readthedocs.org/en/latest/installing.html", file=sys.stderr)
-            sys.exit(1)
-
-    try:
-        installRequiredModules(needed)
-    except OSError:
-        sys.exit(1)
-
-# ------
+from contextlib import contextmanager
+from pathlib import Path
+from typing import List, Optional, Generator
+from urllib.parse import unquote, urljoin
 
 import requests
 from bs4 import BeautifulSoup
 
-BASE_URL = 'https://downloads.khinsider.com/'
-
-# Although some of these are valid on Linux, keeping this the same
-# across systems is nice for consistency AND it works on WSL.
+# Precompiled regex patterns for HTML preprocessing
+PRE_TD_RE = re.compile(br"^</td>\s*$", flags=re.MULTILINE)
+INVALID_ENTITY_RE = re.compile(br"&#([^0-9x]|x[^0-9A-Fa-f])")
 FILENAME_INVALID_RE = re.compile(r'[<>:"/\\|?*]')
-def to_valid_filename(s):
-    # Windows's Explorer doens't handle filenames that end in ' ' or '.'.
-    s = s.rstrip(' .')
 
-    if s in {'', '.', '..', '~', 'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2',
-             'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1',
-             'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'}:
-        return s + '_'
-
-    return FILENAME_INVALID_RE.sub('-', s)
+BASE_URL = 'https://downloads.khinsider.com/'
+SCRIPT_NAME = Path(sys.argv[0]).name
+REPORT_URL = "https://github.com/obskyr/khinsider/issues"
+MAX_RETRIES = 3
+CHUNK_SIZE = 65536  # 64KB chunks for download streaming
 
 
-# Different printin' for different Pythons.
-def unicodePrint(*args, **kwargs):
-    unicodeType = str if sys.version_info[0] > 2 else unicode
-    encoding = sys.stdout.encoding or 'utf-8'
-    args = [
-        arg.encode(encoding, 'replace').decode(encoding)
-        if isinstance(arg, unicodeType) else arg
-        for arg in args
-    ]
-    print(*args, **kwargs)
+class ScriptError(Exception):
+    """Base exception for script-specific errors."""
 
 
-def lazyProperty(func):
-    attrName = '_lazy_' + func.__name__
-    @property
-    @wraps(func)
-    def lazyVersion(self):
-        if not hasattr(self, attrName):
-            setattr(self, attrName, func(self))
-        return getattr(self, attrName)
-    return lazyVersion
+class NetworkError(ScriptError):
+    """Raised when network operations fail after multiple attempts."""
 
 
-def getSoup(*args, **kwargs):
-    r = requests.get(*args, **kwargs)
-    return toSoup(r)
-
-REMOVE_RE = re.compile(br"^</td>\s*$", re.MULTILINE)
-BAD_AMPERSAND_RE = re.compile(br"&#([^0-9x]|x[^0-9A-Fa-f])")
-def toSoup(r):
-    content = r.content
-    # Fix errors in khinsider's HTML.
-    content = REMOVE_RE.sub(b'', content)
-    content = BAD_AMPERSAND_RE.sub(b'&amp;#\1', content)
-
-    # BS4 outputs unsuppressable error messages when it can't
-    # decode the input bytes properly. This... suppresses them.
-    with Silence():
-        return BeautifulSoup(content, 'html.parser')
+class InvalidSoundtrackError(ScriptError):
+    """Raised when requested soundtrack doesn't exist or is unavailable."""
 
 
-def getAppropriateFile(song, formatOrder):
-    if formatOrder is None:
-        return song.files[0]
+class InvalidFormatError(ScriptError):
+    """Raised when none of the requested audio formats are available."""
+
+
+@contextmanager
+def suppress_output() -> Generator[None, None, None]:
+    """Context manager to suppress all stdout/stderr output.
     
-    for extension in formatOrder:
-        for file in song.files:
-            if os.path.splitext(file.filename)[1][1:].lower() == extension:
-                return file
-    
-    return song.files[0]
-
-
-def friendlyDownloadFile(file, path, index, total, verbose=False):
-    numberStr = "{}/{}".format(
-        str(index).zfill(len(str(total))),
-        str(total)
-    )
-
-    if file is None and verbose:
-        print("Song {} is nonexistent (404: Not Found). Skipping over.".format(numberStr), file=sys.stderr)
-        return False
-
-    encoding = sys.getfilesystemencoding()
-    # Fun(?) fact: on Python 2, sys.getfilesystemencoding returns 'mbcs' even
-    # on Windows NT (1993!) and later where filenames are natively Unicode.
-    encoding = 'utf-8' if encoding == 'mbcs' else 'utf-8'
-    filename = file.filename.encode(encoding, 'replace').decode(encoding)
-
-    byTheWay = ""
-    if filename != file.filename:
-        byTheWay = " (replaced characters not in the filesystem's \"{}\" encoding)".format(encoding)
-    
-    filename = to_valid_filename(filename)
-    path = os.path.join(path, filename)
-    
-    if not os.path.exists(path):
-        if verbose:
-            unicodePrint("Downloading {}: {}{}...".format(numberStr, filename, byTheWay))
-        for triesElapsed in range(3):
-            if verbose and triesElapsed:
-                unicodePrint("Couldn't download {}. Trying again...".format(filename), file=sys.stderr)
-            try:
-                file.download(path)
-            except (requests.ConnectionError, requests.Timeout):
-                pass
-            else:
-                break
-        else:
-            if verbose:
-                unicodePrint("Couldn't download {}. Skipping over.".format(filename), file=sys.stderr)
-            return False
-    else:
-        if verbose:
-            unicodePrint("Skipping over {}: {}{}. Already exists.".format(numberStr, filename, byTheWay))
-
-    return True
-
-
-class KhinsiderError(Exception):
-    pass
-
-class NonexistentSongError(KhinsiderError):
-    pass
-
-class SoundtrackError(Exception):
-    def __init__(self, soundtrack):
-        self.soundtrack = soundtrack
-
-class NonexistentSoundtrackError(SoundtrackError, ValueError):
-    def __str__(self):
-        ost = '"{}" '.format(self.soundtrack.id) if len(self.soundtrack.id) <= 80 else ""
-        s = "The soundtrack {}does not exist.".format(ost)
-        return s
-
-class NonexistentFormatsError(SoundtrackError, ValueError):
-    def __init__(self, soundtrack, requestedFormats):
-        super(NonexistentFormatsError, self).__init__(soundtrack)
-        self.requestedFormats = requestedFormats
-    def __str__(self):
-        ost = '"{}" '.format(self.soundtrack.id) if len(self.soundtrack.id) <= 80 else ""
-        s = "The soundtrack {}is not available in the requested formats ({}).".format(
-            ost,
-            ", ".join('"{}"'.format(extension) for extension in self.requestedFormats))
-        return s
-
-class Soundtrack(object):
-    """A KHInsider soundtrack. Initialize with a soundtrack ID.
-    
-    Properties:
-    * id:     The soundtrack's unique ID, used at the end of its URL.
-    * url:    The full URL of the soundtrack.
-    * name:   The textual title of the soundtrack.
-    * availableFormats: A list of the formats the soundtrack is available in.
-    * songs:  A list of Song objects representing the songs in the soundtrack.
-    * images: A list of File objects representing the images in the soundtrack.
+    Yields:
+        None: No value yielded, used for context management
     """
+    with open(os.devnull, 'w') as null:
+        original_stdout = sys.stdout
+        original_stderr = sys.stderr
+        sys.stdout = null
+        sys.stderr = null
+        try:
+            yield
+        finally:
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
 
-    def __init__(self, soundtrackId):
-        self.id = soundtrackId
-        self.url = urljoin(BASE_URL, 'game-soundtracks/album/' + self.id)
+
+def sanitize_filename(name: str) -> str:
+    """Convert string to a valid filesystem filename.
     
-    def __repr__(self):
-        return "<{}: {}>".format(self.__class__.__name__, self.id)
-
-    def _isLoaded(self, property):
-        return hasattr(self, '_lazy_' + property)
-
-    @lazyProperty
-    def _contentSoup(self):
-        soup = getSoup(self.url)
-        contentSoup = soup.find(id='pageContent')
-        if contentSoup.find('p').string == "No such album":
-            # The pageContent and p exist even if the soundtrack doesn't, so no
-            # need for error handling here.
-            raise NonexistentSoundtrackError(self)
-        return contentSoup
-
-    @lazyProperty
-    def name(self):
-        return next(self._contentSoup.find('h2').stripped_strings)
-
-    @lazyProperty
-    def availableFormats(self):
-        table = self._contentSoup.find('table', id='songlist')
-        header = table.find('tr')
-        headings = [td.get_text(strip=True) for td in header(['th', 'td'])]
-        formats = [s.lower() for s in headings if s not in {"", "Track", "Song Name", "Download", "Size"}]
-        formats = formats or ['mp3']
-        return formats
-
-    @lazyProperty
-    def songs(self):
-        table = self._contentSoup.find('table', id='songlist')
-        anchors = [tr.find('a') for tr in table('tr') if not tr.find('th')]
-        urls = [a['href'] for a in anchors]
-        songs = [Song(urljoin(self.url, url)) for url in urls]
-        return songs
+    Args:
+        name: Original filename to sanitize
     
-    @lazyProperty
-    def images(self):
-        table = self._contentSoup.find('table')
-        if not table:
-            # Currently, the table is always present, but if it's ever removed
-            # for imageless albums, it should be handled gracefully.
-            return []
-        anchors = [a for a in table('a') if a.find('img')]
-        urls = [a['href'] for a in anchors]
-        images = [File(urljoin(self.url, url)) for url in urls]
-        print(images)
-        return images
+    Returns:
+        Sanitized filename with invalid characters replaced
+    
+    Example:
+        >>> sanitize_filename('A/B?C*.txt')
+        'A-B-C-.txt'
+    """
+    sanitized = FILENAME_INVALID_RE.sub('-', name).rstrip(' .')
+    reserved = {'', '.', '..', '~', 'CON', 'PRN', 'AUX', 'NUL'} | \
+        {f'COM{i}' for i in range(1, 10)} | \
+        {f'LPT{i}' for i in range(1, 10)}
+    
+    if sanitized.upper() in reserved:
+        return f'{sanitized}_'
+    return sanitized
 
-    def download(self, path='', makeDirs=True, formatOrder=None, verbose=False):
-        """Download the soundtrack to the directory specified by `path`!
+
+def get_soup(url: str, session: requests.Session) -> BeautifulSoup:
+    """Fetch and parse HTML content from URL using persistent session.
+    
+    Args:
+        url: URL to fetch content from
+        session: Requests session for connection reuse
+    
+    Returns:
+        BeautifulSoup object containing parsed HTML
         
-        Create any directories that are missing if `makeDirs` is set to True.
+    Raises:
+        NetworkError: If connection fails multiple times
+    """
+    try:
+        with suppress_output():
+            response = session.get(url, timeout=15)
+            response.raise_for_status()
+            
+            # Preprocess HTML to fix common issues
+            content = response.content
+            content = PRE_TD_RE.sub(b'', content)
+            content = INVALID_ENTITY_RE.sub(b'&amp;#\\1', content)
+            
+            return BeautifulSoup(content, 'html.parser')
+    except requests.RequestException as e:
+        raise NetworkError(f"Network error: {e}") from e
 
-        Set `formatOrder` to a list of file extensions to specify the order
-        in which to prefer file formats. If set to ['flac', 'ogg', 'mp3'], for
-        example, FLAC files will be downloaded if available - if not, Ogg
-        files, and if those aren't available, MP3 files.
+
+class Soundtrack:
+    """Represents a KHInsider soundtrack album with download capabilities.
+    
+    Attributes:
+        id (str): Soundtrack ID extracted from URL
+        url (str): Full URL to the album page
+        name (str): Sanitized official album name
+        formats (List[str]): Available audio formats (e.g., ['mp3', 'flac'])
+        songs (List[Song]): List of tracks in the album
+    
+    Example:
+        >>> with requests.Session() as session:
+        ...     ost = Soundtrack('kh2fm-soundtrack', session)
+        ...     print(ost.name)
+        Kingdom Hearts II FM Original Soundtrack
+    """
+    
+    def __init__(self, soundtrack_id: str, session: requests.Session):
+        """Initialize soundtrack with ID and persistent session.
         
-        Print progress along the way if `verbose` is set to True.
-
-        Return True if all files were downloaded successfully, False if not.
+        Args:
+            soundtrack_id: Album ID from KHInsider URL
+            session: Shared requests session for HTTP connections
         """
-        path = os.path.join(getcwd(), path)
-        path = os.path.abspath(os.path.realpath(path))
-        if formatOrder:
-            formatOrder = [extension.lower() for extension in formatOrder]
-            if not set(self.availableFormats) & set(formatOrder):
-                raise NonexistentFormatsError(self, formatOrder)
+        self.id = soundtrack_id
+        self.session = session
+        self.url = urljoin(BASE_URL, f'game-soundtracks/album/{self.id}')
+        self._soup = None
+        self._name = None
+        self._formats = None
+        self._songs = None
 
-        if verbose and not self._isLoaded('songs'):
-            print("Getting song list...")
-        files = []
-        for song in self.songs:
-            try:
-                files.append(getAppropriateFile(song, formatOrder))
-            except NonexistentSongError:
-                files.append(None)
-        files.extend(self.images)
-        totalFiles = len(files)
+    @property
+    def name(self) -> str:
+        """Get official soundtrack name with sanitization.
+        
+        Returns:
+            Safe-to-use filename string
+            
+        Raises:
+            InvalidSoundtrackError: If album page indicates missing content
+        """
+        if not self._name:
+            soup = self._get_content()
+            name_tag = soup.find('h2')
+            if not name_tag:
+                raise InvalidSoundtrackError(f"Invalid album page: {self.url}")
+            self._name = sanitize_filename(name_tag.get_text(strip=True))
+        return self._name
 
-        if makeDirs and not os.path.isdir(path):
-            os.makedirs(os.path.abspath(os.path.realpath(path)))
+    @property
+    def formats(self) -> List[str]:
+        """Get available audio formats from album table headers.
+        
+        Returns:
+            List of lowercase format identifiers
+        """
+        if not self._formats:
+            soup = self._get_content()
+            table = soup.find('table', id='songlist')
+            if not table:
+                return ['mp3']  # Default to MP3 if no table found
+            
+            headers = [th.get_text(strip=True).lower() 
+                       for th in table.find_all('th')]
+            self._formats = [
+                h for h in headers 
+                if h not in {'track', 'song name', 'download', 'size'}
+            ] or ['mp3']
+        return self._formats
+
+    @property
+    def songs(self) -> List['Song']:
+        """Get list of Song objects from track links.
+        
+        Returns:
+            List of Song instances representing album tracks
+        """
+        if not self._songs:
+            soup = self._get_content()
+            table = soup.find('table', id='songlist')
+            links = [tr.find('a')['href'] 
+                     for tr in table.find_all('tr') if tr.find('a')]
+            self._songs = [
+                Song(urljoin(self.url, link), self.session) 
+                for link in links
+            ]
+        return self._songs
+
+    def _get_content(self) -> BeautifulSoup:
+        """Lazy-load and validate album page content.
+        
+        Returns:
+            Parsed BeautifulSoup object of album page
+            
+        Raises:
+            InvalidSoundtrackError: If page contains error messages
+        """
+        if not self._soup:
+            self._soup = get_soup(self.url, self.session)
+            error_text = self._soup.find("No such album")
+            if error_text:
+                raise InvalidSoundtrackError(f"Album {self.id} not found")
+        return self._soup
+
+    def download(
+        self,
+        output_dir: Path,
+        formats: Optional[List[str]] = None,
+        verbose: bool = False
+    ) -> bool:
+        """Download complete soundtrack with format prioritization.
+        
+        Args:
+            output_dir: Target directory for downloaded files
+            formats: Preferred formats in descending priority order
+            verbose: Enable detailed progress output
+            
+        Returns:
+            True if all tracks downloaded successfully
+            
+        Raises:
+            InvalidFormatError: If no requested formats are available
+            OSError: If directory creation fails
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if formats and not set(formats).intersection(self.formats):
+            raise InvalidFormatError(
+                f"Available formats: {', '.join(self.formats)}"
+            )
 
         success = True
-        for fileNumber, file in enumerate(files, 1):
-            if not friendlyDownloadFile(file, path, fileNumber, totalFiles, verbose):
+        total = len(self.songs)
+        pad = len(str(total))
+
+        for idx, song in enumerate(self.songs, 1):
+            try:
+                file = self._select_best_file(song, formats or [])
+                if not self._download_file(
+                    file, 
+                    output_dir,
+                    idx,
+                    total,
+                    pad,
+                    verbose
+                ):
+                    success = False
+            except Exception as e:
+                if verbose:
+                    print(f"Error downloading song {idx}: {e}", file=sys.stderr)
                 success = False
-        
+
         return success
 
+    def _select_best_file(self, song: 'Song', formats: List[str]) -> 'AudioFile':
+        """Select highest priority available format for a track.
+        
+        Args:
+            song: Track to select format from
+            formats: Ordered list of preferred formats
+            
+        Returns:
+            Best matching AudioFile instance
+        """
+        if not formats:
+            return song.files[0]
+            
+        for fmt in formats:
+            fmt_lower = fmt.lower()
+            for file in song.files:
+                if file.extension == fmt_lower:
+                    return file
+        return song.files[0]
 
-class Song(object):
-    """A song on KHInsider.
+    def _download_file(
+        self,
+        file: 'AudioFile',
+        output_dir: Path,
+        current: int,
+        total: int,
+        pad: int,
+        verbose: bool
+    ) -> bool:
+        """Download individual track with retry logic.
+        
+        Args:
+            file: AudioFile to download
+            output_dir: Target directory
+            current: Current track number
+            total: Total tracks to download
+            pad: String padding for progress display
+            verbose: Enable status output
+            
+        Returns:
+            True if download succeeded
+        """
+        dest = output_dir / sanitize_filename(file.filename)
+        if dest.exists():
+            if verbose:
+                print(f"Skipping existing: {dest.name}")
+            return True
+
+        if verbose:
+            progress = f"[{current:0{pad}d}/{total}]"
+            print(f"{progress} Downloading {dest.name}...")
+
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                file.download(dest)
+                return True
+            except requests.RequestException as e:
+                if verbose and attempt < MAX_RETRIES:
+                    print(f"Retry {attempt}/{MAX_RETRIES} for {dest.name}")
+        return False
+
+
+class Song:
+    """Represents a single track with multiple audio format options.
     
-    Properties:
-    * url:   The full URL of the song page.
-    * name:  The name of the song.
-    * files: A list of the song's files - there may be several if the song
-             is available in more than one format.
+    Attributes:
+        url (str): URL of track's detail page
+        name (str): Sanitized track name
+        files (List[AudioFile]): Available audio format options
     """
     
-    def __init__(self, url):
+    def __init__(self, url: str, session: requests.Session):
+        """Initialize track with URL and shared session.
+        
+        Args:
+            url: Full URL to track's page
+            session: Reusable requests session
+        """
         self.url = url
+        self.session = session
+        self._soup = None
+        self._name = None
+        self._files = None
+
+    @property
+    def name(self) -> str:
+        """Extract and sanitize track name from page content."""
+        if not self._name:
+            soup = self._get_soup()
+            name_tag = soup.find_all('p')[2].find('b')
+            self._name = sanitize_filename(name_tag.get_text(strip=True))
+        return self._name
+
+    @property
+    def files(self) -> List['AudioFile']:
+        """Extract available audio file links from page."""
+        if not self._files:
+            soup = self._get_soup()
+            pattern = re.compile(r'/(?:soundtracks|ost)/')
+            links = [a['href'] for a in soup.find_all('a', href=pattern)]
+            self._files = [
+                AudioFile(urljoin(self.url, link), self.session) 
+                for link in links
+            ]
+        return self._files
+
+    def _get_soup(self) -> BeautifulSoup:
+        """Fetch and validate track page content."""
+        if not self._soup:
+            self._soup = get_soup(self.url, self.session)
+            if '404' in self._soup.find('title').text:
+                raise InvalidSoundtrackError(f"Invalid track URL: {self.url}")
+        return self._soup
+
+
+class AudioFile:
+    """Represents a downloadable audio file with metadata.
     
-    def __repr__(self):
-        return "<{}: {}>".format(self.__class__.__name__, self.url)
-    
-    @lazyProperty
-    def _soup(self):
-        r = requests.get(self.url, timeout=10)
-        if r.url.rsplit('/', 1)[-1] == '404':
-            raise NonexistentSongError("Nonexistent song page (404).")
-        return getSoup(self.url)
-
-    @lazyProperty
-    def name(self):
-        return self._soup('p')[2]('b')[1].get_text()
-
-    @lazyProperty
-    def files(self):
-        # The path used to be /ost/..., and was changed to
-        # /soundtracks/... - but who knows? It might change back!
-        anchors = self._soup('a', href=re.compile(r'^https?://[^/]+/(?:soundtracks|ost)/.+$'))
-        return [File(urljoin(self.url, a['href'])) for a in anchors]
-
-
-class File(object):
-    """A file belonging to a soundtrack on KHInsider.
-    
-    Properties:
-    * url:      The full URL of the file.
-    * filename: The file's... filename. You got it.
+    Attributes:
+        url (str): Direct download URL
+        filename (str): Original filename from URL
+        extension (str): Lowercase file extension
     """
-
-    def __init__(self, url):
+    
+    def __init__(self, url: str, session: requests.Session):
+        """Initialize with download URL and session.
+        
+        Args:
+            url: Direct download URL
+            session: Shared requests session
+        """
         self.url = url
+        self.session = session
+        self.filename = unquote(Path(url).name)
+        self.extension = Path(url).suffix[1:].lower()
 
-        try:
-            url = str(url)
-        except UnicodeError:
-            # Python 2's quote and unquote work with bytestrings.
-            url = url.encode('utf-8')
-        # str('/') makes sure the string doesn't get
-        # converted to a Unicode string on Python 2.
-        self.filename = unquote(url.rsplit(str('/'), 1)[-1])
-        try:
-            # In Python 2, unquote doesn't handle escaped UTF-8 characters
-            # automatically, so we gotta decode them manually from bytes.
-            self.filename = self.filename.decode('utf-8')
-        except AttributeError:
-            pass
-
-    def __repr__(self):
-        return "<{}: {}>".format(self.__class__.__name__, self.url)
-    
-    def download(self, path):
-        """Download the file to `path`."""
-        response = requests.get(self.url, timeout=10)
-        with open(path, 'wb') as outFile:
-            outFile.write(response.content)
+    def download(self, dest: Path) -> None:
+        """Stream file to disk with large chunk size.
+        
+        Args:
+            dest: Path to save file
+            
+        Raises:
+            requests.RequestException: For network errors
+        """
+        response = self.session.get(self.url, stream=True, timeout=30)
+        response.raise_for_status()
+        
+        with dest.open('wb') as f:
+            for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+                if chunk:  # Filter out keep-alive chunks
+                    f.write(chunk)
 
 
-def download(soundtrackId, path='', makeDirs=True, formatOrder=None, verbose=False):
-    """Download the soundtrack with the ID `soundtrackId`.
-    See Soundtrack.download for more information.
+def main():
     """
-    soundtrack = Soundtrack(soundtrackId)
-    soundtrack.name # To conistently always load the content in advance.
-    path = to_valid_filename(soundtrack.name) if path is None else path
-    if verbose:
-        unicodePrint("Downloading to \"{}\".".format(path))
-    return soundtrack.download(path, makeDirs, formatOrder, verbose)
+    Command-line interface for KHInsider soundtrack downloads.
 
+    This script now spoofs a Chrome browser User-Agent and sets a Referer header
+    to avoid 403 Forbidden errors when fetching pages from KHInsider.
 
-class SearchError(KhinsiderError):
-    pass
+    Usage:
+        python khinsider_checkerberry.py <soundtrack_id> [-o OUTPUT_DIR] [-f FORMATS] [-v]
 
+    Positional arguments:
+      soundtrack           Album ID from KHInsider URL
+                           (e.g. 'kh2fm-soundtrack' from
+                           https://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)
 
-def search(term):
-    """Return a tuple of two lists of Soundtrack objects for the search term
-    `term`. The first tuple contains album name results, and the second song
-    name results.
+    Optional arguments:
+      -o, --output         Output directory (default: album name)
+      -f, --format         Preferred formats, comma-separated (e.g. 'flac,mp3')
+      -v, --verbose        Show detailed progress output
     """
-    r = requests.get(urljoin(BASE_URL, 'search'), params={'search': term})
-    path = urlsplit(r.url).path
-    if path.split('/', 2)[1] == 'game-soundtracks':
-        return [Soundtrack(path.rsplit('/', 1)[-1])]
+    parser = argparse.ArgumentParser(
+        description="Download KHInsider soundtracks (spoofing Chrome UA)",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog=f"Report issues: {REPORT_URL}"
+    )
+    parser.add_argument(
+        'soundtrack',
+        help=(
+            "Album ID from KHInsider URL\n"
+            "(e.g. 'kh2fm-soundtrack' from\n"
+            "https://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)"
+        )
+    )
+    parser.add_argument(
+        '-o', '--output',
+        type=Path,
+        help="Output directory (default: album name)"
+    )
+    parser.add_argument(
+        '-f', '--format',
+        help="Preferred formats, comma-separated (e.g. 'flac,mp3')"
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help="Show detailed progress output"
+    )
 
-    soup = toSoup(r)
+    args = parser.parse_args()
 
-    tables = soup('table', class_='albumList')
-    if not tables:
-        raise SearchError(soup.find('p').get_text(strip=True))
+    try:
+        with requests.Session() as session:
+            session.headers.update({ # Spoof Chrome and set Referer
+                'User-Agent': (
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                    'AppleWebKit/537.36 (KHTML, like Gecko) '
+                    'Chrome/114.0.0.0 Safari/537.36'
+                ),
+                'Referer': 'https://downloads.khinsider.com/'
+            })
 
-    soundtracks = [soundtracksInSearchTable(table) for table in tables]
-    if len(soundtracks) == 1:
-        if "song" in soup.find(id='pageContent').find('p').get_text():
-            soundtracks.insert(0, [])
-        else:
-            soundtracks.append([])
+            ost = Soundtrack(args.soundtrack, session)
+            output_dir = args.output or Path(sanitize_filename(ost.name))
 
-    return soundtracks
+            if ost.download(
+                output_dir=output_dir,
+                formats=args.format.split(',') if args.format else None,
+                verbose=args.verbose
+            ):
+                print("\nDownload completed successfully!")
+                sys.exit(0)
 
-def soundtracksInSearchTable(table):
-    anchors = (tr('td')[1].find('a') for tr in table('tr')[1:])
-    soundtrackParams = [(a['href'].split('/')[-1], a.get_text(strip=True)) for a in anchors]
-
-    soundtracks = []
-    for id, name in soundtrackParams:
-        curSoundtrack = Soundtrack(id)
-        curSoundtrack._lazy_name = name
-        soundtracks.append(curSoundtrack)
-
-    return soundtracks
-
-def printSearchResults(searchResults, file=sys.stdout):
-    padLen = max(len(x.id) for x in chain(*searchResults))
-    s = ""
-    hasPreviousList = False
-    for heading, soundtracks in zip(("Album title results:", "Song name results:"), searchResults):
-        if soundtracks:
-            if hasPreviousList:
-                s += "\n"
-            s += heading + "\n"
-            for soundtrack in soundtracks:
-                s += "{} {}. {}\n".format(soundtrack.id, '.' * (padLen - len(soundtrack.id)), soundtrack.name)
-            hasPreviousList = True
-    unicodePrint(s, end="", file=file)
-
-# --- And now for the execution. ---
-
-if __name__ == '__main__':
-    import argparse
-
-    SCRIPT_NAME = os.path.split(sys.argv[0])[-1]
-    REPORT_STR = ("If it isn't too much to ask, please report to "
-                  "https://github.com/obskyr/khinsider/issues.")
-
-    # Tiny details!
-    class KindArgumentParser(argparse.ArgumentParser):
-        def error(self, message):
-            print("No soundtrack specified! As the first parameter, use the name the soundtrack uses in its URL.", file=sys.stderr)
-            print("If you want to, you can also specify an output directory as the second parameter.", file=sys.stderr)
-            print("You can also search for soundtracks by using your search term as parameter - as long as it's not an existing soundtrack.", file=sys.stderr)
-            print(file=sys.stderr)
-            print("For detailed help and more options, run \"{} --help\".".format(SCRIPT_NAME), file=sys.stderr)
+            print("\nDownload completed with errors!", file=sys.stderr)
             sys.exit(1)
 
-    # More tiny details!
-    class ProperHelpFormatter(argparse.RawTextHelpFormatter):
-        def add_usage(self, usage, actions, groups, prefix=None):
-            if prefix is None:
-                prefix = 'Usage: '
-            return super(ProperHelpFormatter, self).add_usage(usage, actions, groups, prefix)
+    except KeyboardInterrupt:
+        print("\nDownload cancelled.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"\nError: {e}", file=sys.stderr)
+        sys.exit(1)
 
-    def doIt(): # Only in a function to be able to stop after errors, really.
-        parser = KindArgumentParser(description="Download entire soundtracks from KHInsider.\n\n"
-                                    "Examples:\n"
-                                    "%(prog)s jumping-flash\n"
-                                    "%(prog)s katamari-forever \"music{}Katamari Forever OST\"\n"
-                                    "%(prog)s --search persona\n"
-                                    "%(prog)s --format flac mother-3".format(os.sep),
-                                    epilog="Hope you enjoy the script!",
-                                    formatter_class=ProperHelpFormatter,
-                                    add_help=False)
-        
-        try: # Even more tiny details!
-            parser._positionals.title = "Positional arguments"
-            parser._optionals.title = "Optional arguments"
-        except AttributeError:
-            pass
-
-        parser.add_argument('soundtrack',
-                            help="The ID of the soundtrack, used at the end of its URL (e.g. \"jumping-flash\").\n"
-                            "May also simply be the URL of the soundtrack.\n"
-                            "If it doesn't exist (or --search is specified, orrrr too many arguments are supplied),\n"
-                            "all the positional arguments together are used as a search term.")
-        parser.add_argument('outPath', metavar='download directory', nargs='?',
-                            help="The directory to download the soundtrack to.\n"
-                            "Defaults to creating a new directory with the soundtrack ID as its name.")
-        parser.add_argument('trailingArguments', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
-        
-        parser.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
-                            help="Show this help and exit.")
-        parser.add_argument('-f', '--format', default=None, metavar="...",
-                            help="The file format in which to download the soundtrack (e.g. \"flac\").\n"
-                            "You can also specify a comma-separated list of which formats to try\n"
-                            "(for example, \"flac,mp3\": download FLAC if available, otherwise MP3).")
-        parser.add_argument('-s', '--search', action='store_true',
-                            help="Always search, regardless of whether the specified soundtrack ID exists or not.")
-
-        arguments = parser.parse_args()
-
-        try:
-            soundtrack = arguments.soundtrack.decode(sys.getfilesystemencoding())
-        except AttributeError: # Python 3's argv is in Unicode
-            soundtrack = arguments.soundtrack
-        
-        urlRe = re.compile(r"^https?://" + urlsplit(BASE_URL).netloc +
-                           r"/game-soundtracks/album/(?P<soundtrack>[^/]+)$",
-                           re.IGNORECASE)
-        m = urlRe.match(soundtrack)
-        soundtrack = m.group('soundtrack') if m is not None else soundtrack
-
-        outPath = arguments.outPath # Can be None; handled in download().
-
-        # I think this makes the most sense for people who aren't used to the
-        # command line - this'll yield useful results even if you just type
-        # in an entire soundtrack name as arguments without quotation marks.
-        onlySearch = arguments.search or len(arguments.trailingArguments) > 1
-        searchTerm = [soundtrack] + ([outPath] if arguments.outPath is not None else [])
-        searchTerm += arguments.trailingArguments
-        try:
-            searchTerm = ' '.join(arg.decode(sys.getfilesystemencoding()) for arg in searchTerm)
-        except AttributeError: # Python 3, again
-            searchTerm = ' '.join(searchTerm)
-        searchTerm = searchTerm.replace('-', ' ')
-
-        formatOrder = arguments.format
-        if formatOrder:
-            formatOrder = re.split(r',\s*', formatOrder)
-            formatOrder = [extension.lstrip('.').lower() for extension in formatOrder]
-
-        try:
-            if onlySearch:
-                try:
-                    searchResults = search(searchTerm)
-                except SearchError as e:
-                    if re.match(r"^Found [0-9]+ matching albums.$", e.args[0]):
-                        errorStr = "Couldn't search! {}".format(REPORT_STR)
-                    else:
-                        errorStr = "Couldn't search. {}".format(e.args[0])
-                    print(errorStr, file=sys.stderr)
-                else:
-                    if searchResults:
-                        print("Soundtracks found (to download, "
-                              "run \"{} soundtrack-name\")!\n".format(SCRIPT_NAME))
-                        printSearchResults(searchResults)
-                    else:
-                        print("No soundtracks found.")
-            else:
-                try:
-                    success = download(soundtrack, outPath, formatOrder=formatOrder, verbose=True)
-                    if not success:
-                        print("\nNot all files could be downloaded.", file=sys.stderr)
-                        return 1
-                except NonexistentSoundtrackError:
-                    try:
-                        searchResults = search(searchTerm)
-                    except SearchError:
-                        searchResults = None
-                    print("The soundtrack \"{}\" does not seem to exist.".format(soundtrack), file=sys.stderr)
-
-                    if searchResults: # aww yeah we gon' do some searchin'
-                        print("\nThese exist, though:", file=sys.stderr)
-                        printSearchResults(searchResults, file=sys.stderr)
-                    elif searchResults is None:
-                        print("A search for \"{}\" could not be performed either. "
-                              "It may be too short.".format(searchTerm), file=sys.stderr)
-                    
-                    return 1
-                except NonexistentFormatsError as e:
-                    s = ("Format{} not available. "
-                         "The soundtrack \"{}\" is only available in the ").format(
-                        "" if len(formatOrder) == 1 else "s", soundtrack)
-                    
-                    formats = e.soundtrack.availableFormats
-                    if len(formats) == 1:
-                        s += "\"{}\" format.".format(formats[0])
-                    else:
-                        s += "{}{} and \"{}\" formats.".format(
-                            ", ".join('"{}"'.format(extension) for extension in formats[:-1]),
-                            "," if len(formats) > 2 else "",
-                            formats[-1])
-                    
-                    print(s, file=sys.stderr)
-                    
-                    return 1
-                except KeyboardInterrupt:
-                    print("Stopped download.", file=sys.stderr)
-                    return 1
-        except (requests.ConnectionError, requests.Timeout):
-            print("Could not connect to KHInsider.", file=sys.stderr)
-            print("Make sure you have a working internet connection.", file=sys.stderr)
-            return 1
-        except Exception:
-            print(file=sys.stderr)
-            print("An unexpected error occurred! " + REPORT_STR,
-                  file=sys.stderr)
-            print("Attach the following error message:", file=sys.stderr)
-            print(file=sys.stderr)
-            raise
+    """Command-line interface for soundtrack downloads."""
+    parser = argparse.ArgumentParser(
+        description="Download KHInsider soundtracks",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog=f"Report issues: {REPORT_URL}"
+    )
+    parser.add_argument(
+        'soundtrack',
+        help="Album ID from KHInsider URL\n(e.g. 'kh2fm-soundtrack' from\nhttps://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)"
+    )
+    parser.add_argument(
+        '-o', '--output',
+        type=Path,
+        help="Output directory (default: album name)"
+    )
+    parser.add_argument(
+        '-f', '--format',
+        help="Preferred formats, comma-separated\n(e.g. 'flac,mp3')"
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help="Show detailed progress output"
+    )
     
-        return 0
+    args = parser.parse_args()
     
-    sys.exit(doIt())
+    try:
+        with requests.Session() as session:
+            ost = Soundtrack(args.soundtrack, session)
+            output_dir = args.output or Path(sanitize_filename(ost.name))
+            
+            if ost.download(
+                output_dir=output_dir,
+                formats=args.format.split(',') if args.format else None,
+                verbose=args.verbose
+            ):
+                print("\nDownload completed successfully!")
+                sys.exit(0)
+            print("\nDownload completed with errors!", file=sys.stderr)
+            sys.exit(1)
+            
+    except KeyboardInterrupt:
+        print("\nDownload cancelled.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"\nError: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/khinsider.py
+++ b/khinsider.py
@@ -2,61 +2,116 @@
 # -*- coding: utf-8 -*-
 """Download full soundtracks from KHInsider.
 
-This script allows users to download entire music albums from KHInsider by
-specifying the album ID found in the website's URL. It supports multiple audio
-formats, optional album image download, and includes error handling for network
-issues and invalid inputs.
+This script downloads entire music albums from KHInsider given an album ID
+(found in the website's URL) or a full album URL. Multiple audio formats, 
+optional album image download, optional parallel downloads, dry-run
+listing, and includes error handling.
 
-Features:
-  - Automatic directory creation with sanitized names
-  - Format selection prioritization
-  - Optional download of album images (e.g., cover art)
-  - Connection reuse for improved performance
-  - Comprehensive error reporting
+Requires Python 3.9 or newer.
+
+Architecture:
+    Layers:
+
+        1. Domain Entities      pure-data, frozen dataclasses (no I/O).
+                                MediaFile, Track, Album, AlbumSummary,
+                                SearchResults.
+        2. Infrastructure       all HTTP and HTML-parsing knowledge.
+                                KHInsiderClient turns IDs/URLs into
+                                domain entities.
+        3. Application          UI-agnostic file mechanics.
+                                DownloadManager streams to disk
+                                atomically and retries transient
+                                failures, calling a DownloadObserver
+                                at every state transition.
+        4. Presentation         the CLI. CLIProgressObserver and
+                                _OneLineObserver implement the observer
+                                contract; DownloadOrchestrator wires an
+                                Album through DownloadManager. main()
+                                is the composition root.
 
 Usage:
-    python khinsider.py <soundtrack_id> [-o OUTPUT_DIR] [-f FORMATS] [-i] [-v]
+    python khinsider.py <soundtrack_id_or_url> [options]
 
-Options:
-  -o, --output    Output directory (default: sanitized album name)
-  -f, --format    Preferred formats, comma-separated (e.g. 'flac,mp3')
-  -i, --images    Download album images (default: enabled; use --no-images to disable)
-  -v, --verbose   Show detailed progress (default: enabled; use --no-verbose to disable)
+Common options:
+  -o, --output     Output directory (default: sanitized album name)
+  -f, --format     Preferred formats, comma-separated (e.g. 'flac,mp3')
+  -i, --images     Download album images (default: enabled; --no-images to
+                   disable)
+  -v, --verbose    Show detailed progress (default: enabled; --no-verbose to
+                   disable)
+  -s, --search     Search for soundtracks instead of downloading. Also used
+                   automatically if the supplied ID does not exist.
+  -t, --threads    Concurrent file downloads (default: 1, max: 8)
+  -d, --delay      Seconds to wait between sequential downloads (default: 0)
+      --timeout    HTTP timeout in seconds (default: 30)
+      --force      Re-download files that already exist on disk
+      --list-only  Print what would be downloaded and exit
+      --version    Show program version and exit.
+
+Environment variables:
+  KHI_NO_AUTO_INSTALL          Set to '1' to skip automatic dependency install.
+  KHI_AUTO_INSTALL_ATTEMPTED   Internal guard set before re-exec; prevents
+                               infinite re-install loops if pip "succeeds"
+                               but the package is still not importable.
 
 Examples:
     Download Aquaplus Vocal Collection Vol. 4 in FLAC:
         python khinsider.py --format flac "aquaplus-vocal-collection-vol.4"
-    Download Minecraft OST in FLAC or MP3, plus images:
-        python khinsider.py https://downloads.khinsider.com/game-soundtracks/album/minecraft -f flac,mp3 -i -v
+    Download Minecraft OST in FLAC or MP3, plus images, with 2 threads:
+        python khinsider.py -f flac,mp3 -t 2 \\
+            https://downloads.khinsider.com/game-soundtracks/album/minecraft
 
 Report issues: https://github.com/obskyr/khinsider/issues
 """
 
+from __future__ import annotations
+
+import argparse
+import enum
+import errno
 import os
 import re
 import sys
-import math
+import threading
 import time
-import shutil
-import argparse
-import subprocess
-from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Generator, List, Optional, Callable
-import importlib.util
-from urllib.parse import unquote, urljoin
-from dataclasses import dataclass
-from urllib.parse import urlsplit
+from typing import (
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    TYPE_CHECKING,
+    Tuple,
+)
+from urllib.parse import unquote, urljoin, urlsplit
 
+if TYPE_CHECKING:
+    import requests
+    from bs4 import BeautifulSoup, Tag
+    from curl_cffi import requests as _curl_requests
+    from curl_cffi.requests import exceptions as _curl_exceptions
 
-# ------------------------------------------------------------------------------
-# Dependency bootstrap
-# ------------------------------------------------------------------------------
+__version__ = "2.0.0"
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Dependency bootstrap (Set KHI_NO_AUTO_INSTALL=1 to disable auto-install.)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 _REQUIRED_PKGS = {
     "requests": "requests>=2.0,<3.0",
     "bs4": "beautifulsoup4>=4.4,<5.0",
+    "curl_cffi": "curl_cffi>=0.7,<1.0",
 }
+
+_HELP_VERSION_TOKENS = frozenset({"-h", "--help", "--version"})
+
+
+def _wants_help_or_version(argv: List[str]) -> bool:
+    """Return True if the argv vector is just asking for help or version."""
+    return any(arg in _HELP_VERSION_TOKENS for arg in argv[1:])
 
 
 def _in_venv() -> bool:
@@ -65,101 +120,272 @@ def _in_venv() -> bool:
     return sys.prefix != base or hasattr(sys, "real_prefix")
 
 
-def _ensure_pip_available(verbose: bool = False) -> None:
-    """Ensure 'pip' is importable for 'python -m pip' invocations."""
-    try:
-        import pip  # noqa: F401  # pylint: disable=unused-import
-        return
-    except Exception:
-        pass
+def _externally_managed_message() -> str:
+    """Return user-facing guidance for PEP 668 environments."""
+    return (
+        "Your Python installation is marked EXTERNALLY-MANAGED (PEP 668). "
+        "Create and activate a virtual environment, then re-run:\n"
+        f"  {sys.executable} -m venv .venv\n"
+        "  source .venv/bin/activate   # Linux/macOS\n"
+        "  .venv\\Scripts\\activate     # Windows\n"
+        f"  {sys.executable} -m pip install requests beautifulsoup4"
+    )
 
+
+def _run_install_subprocess(cmd: List[str], env: dict) -> None:
+    """Run an install subprocess, surfacing pip output on failure.
+
+    Raises:
+        RuntimeError: If the subprocess returns a non-zero exit code. The
+            captured stderr/stdout is included in the exception message so
+            users can diagnose proxy/permission/SSL/PEP-668 issues.
+    """
+    import subprocess
     try:
-        import ensurepip  # type: ignore  # noqa: F401
-    except Exception as exc:
-        # Use RuntimeError here to avoid depending on later exception classes.
+        result = subprocess.run(
+            cmd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to launch installer ({exc}). Install manually:\n  "
+            + " ".join(cmd)
+        ) from exc
+
+    if result.returncode == 0:
+        return
+
+    detail = (result.stderr or result.stdout or "").strip()
+    if detail:
+        tail = "\n".join(detail.splitlines()[-40:])
+        print(tail, file=sys.stderr)
+
+    if "externally-managed-environment" in detail.lower():
+        print("\n" + _externally_managed_message(), file=sys.stderr)
+
+    raise RuntimeError(
+        "Automatic dependency installation failed. Install manually:\n  "
+        + " ".join(cmd)
+    )
+
+
+def _ensure_pip_available(verbose: bool = False) -> None:
+    """Ensure 'pip' is importable for 'python -m pip' invocations.
+
+    Raises:
+        RuntimeError: If pip cannot be bootstrapped.
+    """
+    import importlib.util
+    if importlib.util.find_spec("pip") is not None:
+        return
+
+    if importlib.util.find_spec("ensurepip") is None:
         raise RuntimeError(
             "pip is not available and the standard library 'ensurepip' module "
             "could not be imported to bootstrap it."
-        ) from exc
+        )
 
     if verbose:
         print("Bootstrapping pip via ensurepip...", file=sys.stderr)
-    subprocess.check_call(
-        [sys.executable, "-m", "ensurepip", "--upgrade"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    _run_install_subprocess(
+        [sys.executable, "-m", "ensurepip", "--upgrade"], os.environ.copy()
     )
 
 
 def _install_with_pip(specs: List[str], verbose: bool = True) -> None:
     """Install the given requirement specs using pip.
 
-    Uses --user when not in a virtualenv to avoid admin rights.
+    Uses ``--user`` when not in a virtualenv to avoid requiring admin rights.
+
+    Raises:
+        RuntimeError: If pip exits non-zero.
     """
     env = os.environ.copy()
     env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
 
-    cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]
+    cmd = [sys.executable, "-m", "pip", "install"]
     if not _in_venv():
         cmd.append("--user")
     cmd.extend(specs)
 
     if verbose:
-        print("Installing required packages: " + ", ".join(specs), file=sys.stderr)
-
-    try:
-        subprocess.check_call(
-            cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        print(
+            "Installing required packages: " + ", ".join(specs),
+            file=sys.stderr,
         )
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            "Automatic dependency installation failed. "
-            "Install manually:\n  " + " ".join(cmd)
-        ) from exc
+
+    _run_install_subprocess(cmd, env)
+
+
+def _print_manual_install_hint(missing: List[str], header: str) -> None:
+    """Print a friendly 'install manually' hint to stderr."""
+    specs = " ".join(_REQUIRED_PKGS[name] for name in missing)
+    print(
+        f"{header}\n"
+        f"  {sys.executable} -m pip install {specs}",
+        file=sys.stderr,
+    )
 
 
 def _ensure_runtime_dependencies(verbose: bool = True) -> None:
     """Ensure third-party dependencies exist; auto-install if missing.
 
-    KHI_NO_AUTO_INSTALL=1 to skip auto-install.
-    """
-    if os.environ.get("KHI_NO_AUTO_INSTALL") == "1":
-        return
+    Behavior:
+      * If all packages are importable, returns immediately.
+      * If ``KHI_NO_AUTO_INSTALL=1``, prints a friendly install hint and
+        exits with code 1 (replaces the previous silent fall-through that
+        produced a bare ``ModuleNotFoundError`` traceback).
+      * If ``KHI_AUTO_INSTALL_ATTEMPTED=1`` is already set, the previous
+        re-exec installed but the package is still missing. Refuse to loop
+        and surface a clear diagnostic.
+      * Otherwise, attempt ``python -m pip install``, then re-exec the
+        script with the guard variable set so any subsequent miss aborts
+        loudly instead of looping.
 
-    missing = [name for name in _REQUIRED_PKGS if importlib.util.find_spec(name) is None]
+    Raises:
+        SystemExit: When manual intervention is required.
+    """
+    import importlib.util
+    import subprocess
+    missing = [
+        name
+        for name in _REQUIRED_PKGS
+        if importlib.util.find_spec(name) is None
+    ]
     if not missing:
         return
 
-    _ensure_pip_available(verbose=verbose)
-    specs = [_REQUIRED_PKGS[name] for name in missing]
-    _install_with_pip(specs, verbose=verbose)
+    if os.environ.get("KHI_NO_AUTO_INSTALL") == "1":
+        _print_manual_install_hint(
+            missing,
+            f"Missing required packages ({', '.join(missing)}) and "
+            "KHI_NO_AUTO_INSTALL=1. Install manually with:",
+        )
+        sys.exit(1)
+
+    if os.environ.get("KHI_AUTO_INSTALL_ATTEMPTED") == "1":
+        _print_manual_install_hint(
+            missing,
+            f"Auto-install of {', '.join(missing)} appeared to succeed, but "
+            "the package is still not importable. This usually means pip "
+            "installed it to a location not on sys.path (wrong Python, "
+            "user-site disabled, or a venv mismatch). Install manually with:",
+        )
+        sys.exit(1)
+
+    try:
+        _ensure_pip_available(verbose=verbose)
+        _install_with_pip(
+            [_REQUIRED_PKGS[name] for name in missing], verbose=verbose
+        )
+    except RuntimeError as exc:
+        print(f"\n{exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if verbose:
+        print(
+            "Dependencies installed. Restarting script to apply changes...",
+            file=sys.stderr,
+        )
+
+    env = os.environ.copy()
+    env["KHI_AUTO_INSTALL_ATTEMPTED"] = "1"
+    if sys.platform == "win32":
+        result = subprocess.run(
+            [sys.executable, *sys.argv], env=env, check=False
+        )
+        sys.exit(result.returncode)
+    os.execve(sys.executable, [sys.executable, *sys.argv], env)
 
 
-# Call the bootstrap BEFORE third-party imports.
-_ensure_runtime_dependencies(verbose=True)
+if __name__ == "__main__" and not _wants_help_or_version(sys.argv):
+    _ensure_runtime_dependencies(verbose="--no-verbose" not in sys.argv)
 
-import requests
-from bs4 import BeautifulSoup
+if not (__name__ == "__main__" and _wants_help_or_version(sys.argv)):  # pylint: disable=wrong-import-position
+    try:
+        import requests
+        from bs4 import BeautifulSoup, Tag
+        from curl_cffi import requests as _curl_requests
+        from curl_cffi.requests import exceptions as _curl_exceptions
+    except ModuleNotFoundError:
+        raise
+
+    _NETWORK_EXCEPTIONS = (
+        requests.RequestException,
+        _curl_exceptions.RequestException,
+    )
+    _HTTP_EXCEPTIONS = (
+        requests.HTTPError,
+        _curl_exceptions.HTTPError,
+    )
 
 
-# ------------------------------------------------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Constants
-# ------------------------------------------------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 BASE_URL = "https://downloads.khinsider.com/"
-MAX_RETRIES = 3
-CHUNK_SIZE = 64 * 1024  # 64KB
 REPORT_URL = "https://github.com/obskyr/khinsider/issues"
 
-# Precompiled regex patterns
-_PRE_TD_RE = re.compile(br"^</td>\s*$", flags=re.MULTILINE)
-_INVALID_ENTITY_RE = re.compile(br"&#([^0-9x]|x[^0-9A-Fa-f])")
+MAX_RETRIES = 3
+CHUNK_SIZE = 64 * 1024  # 64 KiB
+DEFAULT_TIMEOUT = 30.0  # seconds
+DEFAULT_THREADS = 1
+MAX_THREADS = 8
+PREFETCH_WORKERS = 8
+SEARCH_PREFETCH_WORKERS = 8
+
+_PROGRESS_BAR_WIDTH = 28
+_PROGRESS_BAR_RESERVE = 28  # space for byte counts, percent, speed, ETA
+_PROGRESS_REFRESH_HZ = 20  # max frames per second
+_DISPLAY_NAME_WIDTH = 50
+
+_KNOWN_AUDIO_FORMATS = frozenset(
+    {"mp3", "flac", "ogg", "m4a", "aac", "wav", "opus"}
+)
+
+_DEFAULT_FORMAT_PRIORITY: Tuple[str, ...] = (
+    "flac", "wav", "m4a", "ogg", "opus", "mp3", "aac",
+)
+
+_TRANSIENT_OSERROR_ERRNOS = frozenset(
+    n for n in (
+        getattr(errno, "EAGAIN", None),
+        getattr(errno, "EWOULDBLOCK", None),
+        getattr(errno, "ETIMEDOUT", None),
+        getattr(errno, "ECONNRESET", None),
+        getattr(errno, "ECONNABORTED", None),
+        getattr(errno, "EPIPE", None),
+        getattr(errno, "EINTR", None),
+        getattr(errno, "EBUSY", None),
+    )
+    if n is not None
+)
+
+_RETRYABLE_4XX_STATUSES = frozenset({408, 429})
+
+_PRE_TD_RE = re.compile(rb"^</td>\s*$", flags=re.MULTILINE)
+
+_INVALID_ENTITY_RE = re.compile(rb"&#([^0-9x]|x[^0-9A-Fa-f])")
+
 _FILENAME_INVALID_RE = re.compile(r'[<>:"/\\|?*]')
 
+_ALBUM_URL_RE = re.compile(
+    r"^https?://(?:www\.)?downloads\.khinsider\.com/"
+    r"game-soundtracks/album/([^/?#]+)/?(?:[?#].*)?$",
+    flags=re.IGNORECASE,
+)
 
-# ------------------------------------------------------------------------------
+_TRACK_FILE_HREF_RE = re.compile(r"/(?:soundtracks|ost)/")
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Exceptions
-# ------------------------------------------------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 class ScriptError(Exception):
     """Base exception for script-specific errors."""
@@ -176,48 +402,63 @@ class InvalidSoundtrackError(ScriptError):
 class InvalidFormatError(ScriptError):
     """Raised when none of the requested audio formats are available."""
 
+
 class SearchError(ScriptError):
     """Raised when a search operation cannot return results."""
 
 
-# ------------------------------------------------------------------------------
-# Utility Functions
-# ------------------------------------------------------------------------------
+class IncompleteDownloadError(ScriptError):
+    """Raised when a downloaded file's byte count does not match its header.
 
-@contextmanager
-def suppress_output() -> Generator[None, None, None]:
-    """Suppress stdout and stderr temporarily.
-
-    Yields:
-        None
+    Treated as a transient failure by :class:`DownloadManager`, which
+    retries with backoff.
     """
-    with open(os.devnull, "w") as null:
-        orig_stdout, orig_stderr = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = null, null
-        try:
-            yield
-        finally:
-            sys.stdout, sys.stderr = orig_stdout, orig_stderr
 
-_ALBUM_URL_RE = re.compile(
-    r"^https?://(?:www\.)?downloads\.khinsider\.com/"
-    r"game-soundtracks/album/([^/?#]+)(?:/)?$",
-    flags=re.IGNORECASE,
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# URL / filename utilities
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def _extract_id_and_url(value: str) -> Tuple[str, Optional[str]]:
+    """Return (album_id, full_url_if_given_or_None) from user input.
+
+    The full URL is preserved when the user passes one verbatim so callers
+    can reuse it (avoiding a guessed reconstruction that may differ from the
+    canonical URL).
+    """
+    value = value.strip()
+    match = _ALBUM_URL_RE.match(value)
+    if match:
+        return match.group(1), value
+    return value, None
+
+
+def extract_soundtrack_id(candidate: str) -> str:
+    """Return a soundtrack ID from a user-supplied ID or album URL.
+
+    Args:
+        candidate: ID or album URL.
+
+    Returns:
+        The soundtrack ID.
+    """
+    return _extract_id_and_url(candidate)[0]
+
+
+_RESERVED_FS_NAMES = (
+    {"", ".", "..", "~", "CON", "PRN", "AUX", "NUL"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
 )
 
-def _extract_id_and_url(value: str) -> tuple[str, Optional[str]]:
-    """Return (album_id, full_url_if_given_or_None) from user input."""
-    value = value.strip()
-    m = _ALBUM_URL_RE.match(value)
-    if m:
-        return m.group(1), value  # (id, full_url)
-    return value, None
 
 def sanitize_filename(name: str) -> str:
     """Convert a string to a safe filesystem filename.
 
     Invalid characters are replaced with hyphens, trailing spaces or dots are
-    removed, and Windows reserved names are suffixed with an underscore.
+    removed, and Windows reserved names (including reserved stems with an
+    extension, e.g. ``CON.txt``) are suffixed with an underscore.
 
     Args:
         name: Original filename to sanitize.
@@ -228,209 +469,201 @@ def sanitize_filename(name: str) -> str:
     Examples:
         >>> sanitize_filename('A/B?C*.txt')
         'A-B-C-.txt'
+        >>> sanitize_filename('CON.txt')
+        'CON.txt_'
     """
     sanitized = _FILENAME_INVALID_RE.sub("-", name).rstrip(" .")
-    reserved = (
-        {"", ".", "..", "~", "CON", "PRN", "AUX", "NUL"}
-        | {f"COM{i}" for i in range(1, 10)}
-        | {f"LPT{i}" for i in range(1, 10)}
-    )
-    if sanitized.upper() in reserved:
+    stem = sanitized.split(".", 1)[0]
+    if sanitized.upper() in _RESERVED_FS_NAMES or stem.upper() in _RESERVED_FS_NAMES:
         return f"{sanitized}_"
     return sanitized
 
 
-def get_soup(url: str, session: requests.Session) -> BeautifulSoup:
-    """Fetch and parse HTML content from a URL using a persistent session.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# HTML utilities
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Applies preprocessing to fix known HTML issues before parsing.
+
+def _clean_html_bytes(data: bytes) -> bytes:
+    """Apply KHInsider-specific HTML repairs before parsing.
+
+    Strips stray standalone ``</td>`` lines and escapes malformed numeric
+    character references (e.g., ``&#foo`` or ``&#xZZ``) that would otherwise
+    confuse :mod:`html.parser`.
+
+    Args:
+        data: Raw HTML bytes.
+
+    Returns:
+        Cleaned HTML bytes.
+    """
+    data = _PRE_TD_RE.sub(b"", data)
+    data = _INVALID_ENTITY_RE.sub(b"&amp;#\\1", data)
+    return data
+
+
+def _soup_from_bytes(data: bytes) -> "BeautifulSoup":
+    """Parse HTML bytes into BeautifulSoup after KHInsider-specific fixes."""
+    return BeautifulSoup(_clean_html_bytes(data), "html.parser")
+
+
+def _get_soup(
+    url: str,
+    session: "_curl_requests.Session",
+    timeout: float = DEFAULT_TIMEOUT,
+) -> "BeautifulSoup":
+    """Fetch and parse HTML content from a URL using a persistent session.
 
     Args:
         url: The URL to fetch.
         session: Session object for HTTP requests.
+        timeout: Per-request timeout in seconds.
 
     Returns:
         Parsed BeautifulSoup object.
 
     Raises:
-        NetworkError: If the request fails or returns a bad status.
+        NetworkError: If the request fails or returns a bad status. The
+            application-level retry in :class:`DownloadManager` wraps callers
+            that drive bulk fetches, so a single ``NetworkError`` here is
+            surfaced only after that loop has given up.
     """
     try:
-        with suppress_output():
-            response = session.get(url, timeout=30)
-            response.raise_for_status()
-        data = response.content
-        data = _PRE_TD_RE.sub(b"", data)
-        data = _INVALID_ENTITY_RE.sub(b"&amp;#\\1", data)
-        return BeautifulSoup(data, "html.parser")
-    except requests.RequestException as e:
-        raise NetworkError(f"Failed to fetch {url}: {str(e)}") from e
+        response = session.get(url, timeout=timeout)
+        response.raise_for_status()
+    except _NETWORK_EXCEPTIONS as exc:
+        raise NetworkError(f"Failed to fetch {url}: {exc}") from exc
+    return _soup_from_bytes(response.content)
 
-def _soup_from_bytes(data: bytes) -> BeautifulSoup:
-    """Parse HTML bytes into BeautifulSoup after KHInsider-specific fixes.
 
-    Args:
-        data: Raw response content.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Format / size utilities
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Returns:
-        Parsed BeautifulSoup object.
-    """
-    fixed = _PRE_TD_RE.sub(b"", data)
-    fixed = _INVALID_ENTITY_RE.sub(b"&amp;#\\1", fixed)
-    with suppress_output():
-        return BeautifulSoup(fixed, "html.parser")
-
-def extract_soundtrack_id(candidate: str) -> str:
-    """Return a soundtrack ID from a user-supplied ID or album URL.
-
-    If the string looks like a full KHInsider album URL, the final path segment
-    is extracted; otherwise it is returned as-is.
-
-    Args:
-        candidate: ID or album URL.
-
-    Returns:
-        The soundtrack ID.
-    """
-    m = _ALBUM_URL_RE.match(candidate.strip())
-    return m.group(1) if m else candidate.strip()
 
 def _human_size(n: int) -> str:
-    """Return a human-readable size for bytes."""
-    units = ["B", "KB", "MB", "GB", "TB"]
+    """Return a human-readable size for bytes (binary units)."""
+    units = ("B", "KB", "MB", "GB", "TB", "PB")
     size = float(n)
-    for u in units:
-        if size < 1024.0 or u == units[-1]:
-            return f"{size:.1f} {u}"
+    for unit in units[:-1]:
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
         size /= 1024.0
-    return f"{size:.1f} TB"
+    return f"{size:.1f} {units[-1]}"
 
 
 def _fmt_seconds(value: float) -> str:
     """Return whole seconds with an 's' suffix (e.g., '62s')."""
-    return f"{int(max(0, math.ceil(value)))}s"
+    import math
+    return f"{max(0, math.ceil(value))}s"
+
+
+def _truncate_display_name(name: str) -> str:
+    """Return ``name`` truncated to fit the per-file display column."""
+    if len(name) > _DISPLAY_NAME_WIDTH:
+        return name[: _DISPLAY_NAME_WIDTH - 1] + "…"
+    return name
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Progress bar (presentation primitive shared by the CLI observers)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 class _ProgressBar:
     """Simple progress bar with speed and ETA.
 
-    The bar renders to `sys.stdout` on TTYs using a single in-place line and
-    throttles updates to ~20 FPS. When the total size is unknown, it shows a
+    Renders to ``sys.stdout`` on TTYs using a single in-place line and
+    throttles updates to ~20 FPS. When the total size is unknown, shows a
     spinner with bytes transferred, transfer speed, and elapsed time. When the
-    total is known, it shows a filled bar, bytes done/total, percent, speed,
+    total is known, shows a filled bar, bytes done/total, percent, speed,
     and ETA in seconds.
 
-    The instance is a callable: call it with the number of newly written bytes
+    The instance is callable: call it with the number of newly written bytes
     to update the bar. Call :meth:`close` once per file to finalize output.
-
-    Attributes:
-      prefix: Text placed before the bar (typically a filename and index).
-      total: Total number of bytes expected, or None if unknown.
-      width: Character width of the bar body (inside the brackets).
-      n: Total number of bytes observed so far (monotonically increasing).
-      _start: Monotonic timestamp when the bar started (seconds).
-      _last_print: Monotonic timestamp of the last render (seconds).
-      _tty: True if `sys.stdout` is a TTY; disables rendering when False.
-      _last_len: Length of the last rendered line (used to clear leftovers).
     """
 
-    def __init__(self, prefix: str, total: Optional[int], width: int = 28):
+    def __init__(
+        self,
+        prefix: str,
+        total: Optional[int],
+        width: int = _PROGRESS_BAR_WIDTH,
+    ):
         """Initialize a new progress bar.
 
         Adjusts the prefix to fit the current terminal width, reserving space
         for the bar and metrics. Rendering is automatically disabled when
-        `sys.stdout` is not a TTY.
-
-        Args:
-          prefix: Text to display before the bar (e.g., "[01/10] file.ext").
-          total: Expected total bytes for the transfer; None if unknown.
-          width: Width of the bar body (characters inside the brackets).
+        ``sys.stdout`` is not a TTY.
         """
         self.prefix = prefix
         self.total = total
         self.width = max(10, width)
         self.n = 0
-        self._start = time.time()
+        self._start = time.monotonic()
         self._last_print = 0.0
         self._tty = sys.stdout.isatty()
         self._last_len = 0
+        self._closed = False
+        self._cols = self._terminal_cols()
 
-        # Fit bar width to terminal if possible.
-        try:
-            cols = shutil.get_terminal_size(fallback=(80, 20)).columns
-        except Exception:
-            cols = 80
-        # Reserve room for metrics; trim prefix if needed.
-        reserve = 28 + self.width  # numbers + bar
-        if len(prefix) + 1 + reserve > cols:
-            trim_to = max(8, cols - reserve - 1)
+        reserve = _PROGRESS_BAR_RESERVE + self.width
+        if len(prefix) + 1 + reserve > self._cols:
+            trim_to = max(8, self._cols - reserve - 1)
             if len(prefix) > trim_to:
                 self.prefix = prefix[: trim_to - 1] + "…"
 
-    def __call__(self, delta: int, total_hint: Optional[int] = None) -> None:
-        """Advance the bar by `delta` bytes and render if appropriate.
+    @staticmethod
+    def _terminal_cols() -> int:
+        """Return the current terminal width, falling back to 80."""
+        import shutil
+        try:
+            return shutil.get_terminal_size(fallback=(80, 20)).columns
+        except OSError:
+            return 80
 
-        This method is typically used as a callback from the downloader. It
-        updates the internal byte count and triggers a redraw at most ~20 times
-        per second (or always on completion). If a `total_hint` is provided and
-        the bar was created with an unknown total, the hint is adopted.
+    def __call__(self, delta: int, total_hint: Optional[int] = None) -> None:
+        """Advance the bar by ``delta`` bytes and render if appropriate.
+
+        Updates the internal byte count and triggers a redraw at most ~20
+        times per second (or always on completion). Negative ``delta`` values
+        are clamped to zero. If a ``total_hint`` is provided and the bar was
+        created with an unknown total, the hint is adopted.
 
         Rendering is skipped when stdout is not a TTY, but counters are still
-        updated.
-
-        Args:
-          delta: Number of newly transferred bytes to add (non-negative).
-          total_hint: Optional total bytes discovered mid-transfer.
-
-        Raises:
-          ValueError: If `delta` is negative.
+        updated so the final render reflects the true byte count.
         """
         if total_hint and self.total is None:
             self.total = total_hint
         self.n += max(0, int(delta))
 
-        # Print at ~20 FPS max and on completion.
-        now = time.time()
-        if not self._tty:
+        if not self._tty or self._closed:
             return
+
+        now = time.monotonic()
         if self.total is not None and self.n >= self.total:
             self._render()
             return
-        if now - self._last_print >= 0.05:
+        if now - self._last_print >= 1.0 / _PROGRESS_REFRESH_HZ:
             self._last_print = now
             self._render()
 
     def close(self) -> None:
         """Finalize the bar and end the line.
 
-        Ensures a final render (useful for unknown totals), prints a newline so
-        subsequent output starts on a fresh line, and resets internal render
-        length bookkeeping.
-
-        This should be called exactly once per transfer that used the bar.
-        Calling it multiple times is harmless.
+        Idempotent: subsequent calls are no-ops.
         """
+        if self._closed:
+            return
+        self._closed = True
         if self._tty:
             self._render()
-            print("")  # newline
+            print("")
             self._last_len = 0
 
     def _render(self) -> None:
-        """Render the current bar state to stdout.
-
-        For known totals, shows a proportional bar, bytes done/total, percent,
-        speed (binary units per second), and ETA as whole seconds with an 's'
-        suffix. For unknown totals, shows a spinner with bytes done, speed, and
-        elapsed time as whole seconds prefixed with '+'.
-
-        The output is trimmed to the terminal width and padded with spaces to
-        overwrite any leftover characters from a longer previous render.
-
-        Args:
-          final: If True, forces a final render (e.g., at 100%) regardless of
-            throttle timing.
-        """
-        cols = shutil.get_terminal_size(fallback=(80, 20)).columns
-        elapsed = max(1e-9, time.time() - self._start)
+        """Render the current bar state to stdout."""
+        cols = self._cols
+        elapsed = max(1e-9, time.monotonic() - self._start)
         speed = self.n / elapsed
         speed_s = f"{_human_size(int(speed))}/s"
 
@@ -438,521 +671,1619 @@ class _ProgressBar:
             pct = min(1.0, self.n / self.total)
             filled = int(self.width * pct)
             head = ">" if filled < self.width else ""
-            bar = "[" + "=" * filled + head + "." * (self.width - filled - len(head)) + "]"
+            bar = (
+                "["
+                + "=" * filled
+                + head
+                + "." * (self.width - filled - len(head))
+                + "]"
+            )
             done_s = _human_size(self.n)
             total_s = _human_size(self.total)
             remain = (self.total - self.n) / speed if speed > 0 else 0.0
             eta_str = _fmt_seconds(remain)
-            line = (f"{self.prefix} {bar} {done_s}/{total_s} ({int(pct*100):3d}%) "
-                    f"{speed_s} ETA {eta_str}")
+            line = (
+                f"{self.prefix} {bar} {done_s}/{total_s} "
+                f"({int(pct * 100):3d}%) {speed_s} ETA {eta_str}"
+            )
         else:
             spin = "|/-\\"
-            idx = int(time.time() * 10) % len(spin)
-            bar = f"[{spin[idx]}{' ' * (self.width - 1)}]"
+            idx = int(time.monotonic() * 10) % len(spin)
+            spaces = " " * (self.width - 1)
+            bar = f"[{spin[idx]}{spaces}]"
             done_s = _human_size(self.n)
             elapsed_str = _fmt_seconds(elapsed)
             line = f"{self.prefix} {bar} {done_s} {speed_s} +{elapsed_str}"
 
-        # Trim to terminal width
         out = line[: max(0, cols - 1)]
-
-        # Clear any leftover chars from previous, longer render.
         pad = " " * max(0, self._last_len - len(out))
-        print("\r" + out + pad, end="", flush=True)
-
+        try:
+            print("\r" + out + pad, end="", flush=True)
+        except BrokenPipeError:
+            self._tty = False
         self._last_len = len(out)
 
 
-# ------------------------------------------------------------------------------
-# Core Classes
-# ------------------------------------------------------------------------------
+# ==============================================================================
+# Layer 1 - Domain Entities
+# ==============================================================================
 
 
-class AudioFile:
-    """Metadata and download logic for a single file (audio or image).
-
-    Args:
-        url: Direct download URL.
-        session: Shared HTTP session.
+@dataclass(frozen=True)
+class MediaFile:
+    """A single downloadable file (audio track or album image).
 
     Attributes:
-        url: Download URL.
-        filename: Decoded filename from the URL.
-        extension: File extension (lowercase).
+        filename: The decoded basename of the URL path. This is the name
+            the file should be saved under on disk.
+        url: Absolute URL to download the bytes from.
+        extension: Lowercase file extension, no leading dot
+            (e.g. ``"flac"``). Empty string when the URL has no extension.
     """
 
-    def __init__(self, url: str, session: requests.Session):
-        self.url = url
-        self.session = session
-        self.filename = unquote(Path(url).name)
-        self.extension = Path(url).suffix.lstrip(".").lower()
+    filename: str
+    url: str
+    extension: str
 
-    def download(
-        self,
-        dest: Path,
-        progress: Optional[Callable[[int, Optional[int]], None]] = None,
-    ) -> None:
-        """Stream the file to disk.
+    @classmethod
+    def from_url(cls, url: str) -> "MediaFile":
+        """Build a :class:`MediaFile` by deriving the filename from the URL.
+
+        The filename is parsed out of the URL path explicitly (rather than
+        via :class:`pathlib.Path`, which only accidentally works on Windows
+        because ``/`` is a path separator there).
+        """
+        path = urlsplit(url).path
+        filename = unquote(path.rsplit("/", 1)[-1])
+        suffix = filename.rsplit(".", 1)
+        extension = suffix[-1].lower() if len(suffix) == 2 else ""
+        return cls(filename=filename, url=url, extension=extension)
+
+
+@dataclass(frozen=True)
+class Track:
+    """A single album track and the formats it is available in.
+
+    Attributes:
+        name: Display name extracted from the album's songlist row. Used
+            for human-facing labels; the on-disk filename comes from the
+            chosen :class:`MediaFile`.
+        files: All downloadable formats, in source order.
+    """
+
+    name: str
+    files: Tuple[MediaFile, ...]
+
+    def best_file(self, preferences: Sequence[str]) -> MediaFile:
+        """Return the highest-priority available file.
+
+        ``preferences`` should be lowercased by the caller. When empty,
+        falls back to :data:`_DEFAULT_FORMAT_PRIORITY` (lossless first,
+        then lossy by approximate fidelity), so "auto" actually means
+        "best available" rather than "first in HTML order". When none of
+        the preferred extensions are present, falls back to ``files[0]``
+        — matching the legacy "take whatever is offered first" behavior.
 
         Args:
-            dest: Destination path.
-            progress: Optional callback receiving (delta_bytes, total_bytes).
+            preferences: Preferred file extensions, lowercased, in
+                priority order.
+
+        Returns:
+            The selected :class:`MediaFile`.
 
         Raises:
-            requests.RequestException: On network error.
+            InvalidSoundtrackError: If the track has no downloadable
+                files at all (i.e., metadata fetch returned nothing).
         """
-        resp = self.session.get(self.url, stream=True, timeout=30)
-        resp.raise_for_status()
-        total: Optional[int] = None
-        length = resp.headers.get("Content-Length")
-        if length and length.isdigit():
-            total = int(length)
-
-        if progress:
-            progress(0, total)
-
-        with dest.open("wb") as f:
-            for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
-                if chunk:
-                    f.write(chunk)
-                    if progress:
-                        progress(len(chunk), total)
+        if not self.files:
+            raise InvalidSoundtrackError(
+                f"Track {self.name!r} has no downloadable files."
+            )
+        effective = list(preferences) if preferences else list(
+            _DEFAULT_FORMAT_PRIORITY
+        )
+        for fmt in effective:
+            for media in self.files:
+                if media.extension == fmt:
+                    return media
+        return self.files[0]
 
 
-class Song:
-    """Represents a single track with multiple format options.
+@dataclass(frozen=True)
+class Album:
+    """A fully-resolved KHInsider album.
 
-    Args:
-        url: URL of the track detail page.
-        session: Shared HTTP session.
+    All fields are populated up-front by :meth:`KHInsiderClient.get_album`,
+    so an :class:`Album` represents a known-good snapshot of the album
+    page (and every track-detail page it links to) at fetch time.
+
+    Attributes:
+        id: Album identifier (the URL slug).
+        name: Display title, already sanitized for filesystem use.
+        url: Canonical album URL.
+        formats: Available audio formats, in source order, intersected
+            with :data:`_KNOWN_AUDIO_FORMATS` so unrelated columns
+            (``length``, ``artist``) don't appear.
+        tracks: Tracks in source order. A track may have ``files=()`` if
+            its detail page failed to load during prefetch.
+        images: Album images (cover art, etc.) in source order.
     """
 
-    def __init__(self, url: str, session: requests.Session):
-        self.url = url
-        self.session = session
-        self._soup: Optional[BeautifulSoup] = None
-        self._name: Optional[str] = None
-        self._files: Optional[List[AudioFile]] = None
-
-    @property
-    def name(self) -> str:
-        """Extract and sanitize the track name."""
-        if self._name is None:
-            soup = self._load_soup()
-            name_tag = soup.find_all("p")[2].find("b")  # type: ignore
-            self._name = sanitize_filename(name_tag.get_text(strip=True))  # type: ignore
-        return self._name
-
-    @property
-    def files(self) -> List[AudioFile]:
-        """List available audio format options."""
-        if self._files is None:
-            soup = self._load_soup()
-            pattern = re.compile(r"/(?:soundtracks|ost)/")
-            links = [a["href"] for a in soup.find_all("a", href=pattern)]  # type: ignore
-            self._files = [
-                AudioFile(urljoin(self.url, link), self.session)  # type: ignore
-                for link in links
-            ]
-        return self._files
-
-    def _load_soup(self) -> BeautifulSoup:
-        """Lazy-load and cache the BeautifulSoup for this track page.
-
-        Raises:
-            InvalidSoundtrackError: If the page returns a 404-like title.
-        """
-        if self._soup is None:
-            self._soup = get_soup(self.url, self.session)
-            title_text = self._soup.find("title").get_text()  # type: ignore
-            if "404" in title_text:
-                raise InvalidSoundtrackError(f"Track not found: {self.url}")
-        return self._soup
+    id: str
+    name: str
+    url: str
+    formats: Tuple[str, ...]
+    tracks: Tuple[Track, ...]
+    images: Tuple[MediaFile, ...]
 
 
-class Soundtrack:
-    """Handles album metadata and bulk download operations.
+@dataclass(frozen=True)
+class _AlbumMetadata:
+    """Intermediate result of :meth:`KHInsiderClient.fetch_album_metadata`.
 
-    Args:
-        soundtrack_id: Album ID from KHInsider URL.
-        session: Shared HTTP session.
+    Carries an :class:`Album` whose tracks have empty ``files`` plus the
+    parallel track-detail link list that :meth:`prefetch_track_files`
+    needs to fill them in. Internal to the client/CLI handshake.
+
+    Attributes:
+        album: A partial :class:`Album` with skeleton tracks.
+        track_links: ``(display_name, detail_url)`` per track, in the
+            same order as ``album.tracks``.
+    """
+
+    album: Album
+    track_links: Tuple[Tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class AlbumSummary:
+    """A lightweight album reference, e.g. one row in search results.
+
+    Use :meth:`KHInsiderClient.resolve_summary_names` to fill in any
+    missing names without paying for a full album fetch.
 
     Attributes:
         id: Album identifier.
-        url: Full album page URL.
+        name: Display title, sanitized. Empty string when the populating
+            call did not (or could not) determine the name.
+        url: Canonical album URL.
     """
 
-    def __init__(self, soundtrack_id: str, session: requests.Session):
-        album_id, full_url = _extract_id_and_url(soundtrack_id)
-        self.id = album_id
-        self.session = session
-        # If the user passed a full album URL, use it verbatim. Otherwise build it.
-        self.url = full_url or urljoin(BASE_URL, f"game-soundtracks/album/{self.id}")
-        self._soup: Optional[BeautifulSoup] = None
-        self._name: Optional[str] = None
-        self._formats: Optional[List[str]] = None
-        self._songs: Optional[List[Song]] = None
-        self._images: Optional[List[AudioFile]] = None
+    id: str
+    name: str
+    url: str
 
-    @property
-    def name(self) -> str:
-        """Get the official album name, sanitized for filesystem use.
-
-        Raises:
-            InvalidSoundtrackError: If the album page is invalid.
-        """
-        if self._name is None:
-            soup = self._get_page()
-            name_tag = soup.find("h2")
-            if name_tag is None:
-                raise InvalidSoundtrackError(f"Album page invalid: {self.url}")
-            self._name = sanitize_filename(name_tag.get_text(strip=True))
-        return self._name
-
-    @property
-    def formats(self) -> List[str]:
-        """List available audio formats (e.g., ['mp3', 'flac'])."""
-        if self._formats is None:
-            soup = self._get_page()
-            table = soup.find("table", id="songlist")
-            if table is None:
-                self._formats = ["mp3"]
-            else:
-                headers = [th.get_text(strip=True).lower()
-                           for th in table.find_all("th")]  # type: ignore
-                self._formats = [
-                    h for h in headers
-                    if h not in {"track", "song name", "download", "size"}
-                ] or ["mp3"]
-        return self._formats
-
-    @property
-    def songs(self) -> List[Song]:
-        """List Song objects for each track in the album."""
-        if self._songs is None:
-            soup = self._get_page()
-            table = soup.find("table", id="songlist")
-            links = [
-                tr.find("a")["href"]  # type: ignore
-                for tr in table.find_all("tr")  # type: ignore
-                if tr.find("a")  # type: ignore
-            ]
-            self._songs = [
-                Song(urljoin(self.url, link), self.session)  # type: ignore
-                for link in links
-            ]
-        return self._songs
-
-    @property
-    def images(self) -> List[AudioFile]:
-        """List album image files available for download."""
-        if self._images is None:
-            soup = self._get_page()
-            table = soup.find("table")
-            anchors = [
-                a for a in table.find_all("a")  # type: ignore
-                if a.find("img")  # type: ignore
-            ] if table else []
-            self._images = [
-                AudioFile(urljoin(self.url, a["href"]), self.session)  # type: ignore
-                for a in anchors
-            ]
-        return self._images
-
-    def _get_page(self) -> BeautifulSoup:
-        """Lazy-load and validate the album page HTML.
-
-        Raises:
-            InvalidSoundtrackError: If the album is not found.
-        """
-        if self._soup is None:
-            self._soup = get_soup(self.url, self.session)
-            if self._soup.find(string="No such album"):
-                raise InvalidSoundtrackError(f"Album not found: {self.id}")
-        return self._soup
-
-    def download(self,
-                 output_dir: Path,
-                 formats: Optional[List[str]] = None,
-                 download_images: bool = False,
-                 verbose: bool = False) -> bool:
-        """Download the entire soundtrack and optionally album images.
-
-        Args:
-            output_dir: Directory to save tracks (and images) into.
-            formats: Preferred audio formats in priority order.
-            download_images: If True, also download album images.
-            verbose: If True, show per-file progress.
-
-        Returns:
-            True if all requested files downloaded successfully.
-
-        Raises:
-            InvalidFormatError: If no requested audio formats are available.
-            OSError: If output directory creation fails.
-        """
-        output_dir.mkdir(parents=True, exist_ok=True)
-        if formats and not set(formats).intersection(self.formats):
-            raise InvalidFormatError(f"Available formats: {', '.join(self.formats)}")
-
-        total_tracks = len(self.songs)
-        pad_tracks = len(str(total_tracks))
-        success = True
-
-        # Download audio tracks
-        for idx, song in enumerate(self.songs, start=1):
-            try:
-                chosen = self._select_best(song, formats or [])
-                if not self._save_item(chosen, output_dir, idx, total_tracks, pad_tracks, verbose):
-                    success = False
-            except Exception as e:
-                success = False
-                if verbose:
-                    print(f"Error downloading track {idx}: {str(e)}", file=sys.stderr)
-
-        # Download images if requested
-        if download_images:
-            total_imgs = len(self.images)
-            pad_imgs = len(str(total_imgs))
-            for idx, img in enumerate(self.images, start=1):
-                try:
-                    if not self._save_item(img, output_dir, idx, total_imgs, pad_imgs, verbose):
-                        success = False
-                except Exception as e:
-                    success = False
-                    if verbose:
-                        print(f"Error downloading image {idx}: {str(e)}", file=sys.stderr)
-
-        return success
-
-    def _select_best(self, song: Song, prefs: List[str]) -> AudioFile:
-        """Choose the highest-priority available AudioFile for a song."""
-        if not prefs:
-            return song.files[0]
-        for fmt in prefs:
-            for f in song.files:
-                if f.extension == fmt.lower():
-                    return f
-        return song.files[0]
-
-    def _save_item(
-        self,
-        item: AudioFile,
-        output_dir: Path,
-        idx: int,
-        total: int,
-        pad: int,
-        verbose: bool,
-    ) -> bool:
-        """Download a single file with retry logic.
-
-        Args:
-            item: AudioFile object to download.
-            output_dir: Destination directory.
-            idx: Index of this file in its category.
-            total: Total number of files in its category.
-            pad: Width for zero-padding progress numbers.
-            verbose: If True, print progress messages.
-
-        Returns:
-            True if download succeeded or was skipped.
-        """
-        dest = output_dir / sanitize_filename(item.filename)
-        if dest.exists():
-            if verbose:
-                print(f"[{idx:0{pad}d}/{total}] Skipping existing: {dest.name}")
-            return True
-
-        label = f"[{idx:0{pad}d}/{total}] {dest.name}"
-
-        use_bar = verbose and sys.stdout.isatty()
-        bar: Optional[_ProgressBar] = _ProgressBar(prefix=label, total=None) if use_bar else None
-        if verbose and not use_bar:
-            print(f"{label} ...")
-
-        for attempt in range(1, MAX_RETRIES + 1):
-            try:
-                if bar:
-                    bar(0, None)
-                    item.download(dest, progress=bar)
-                    bar.close()
-                else:
-                    item.download(dest)
-                return True
-            except requests.RequestException:
-                if bar:
-                    bar.close()  # ensure newline before retry message
-                if verbose and attempt < MAX_RETRIES:
-                    print(f"Retry {attempt}/{MAX_RETRIES} for {dest.name}")
-                if bar:
-                    bar = _ProgressBar(prefix=label, total=None)
-            except Exception:
-                if bar:
-                    bar.close()
-                raise
-        return False
 
 @dataclass(frozen=True)
 class SearchResults:
-    """Container for search results."""
-    albums: List["Soundtrack"]
-    songs: List["Soundtrack"]
+    """The two result tables a KHInsider search may return.
 
-
-def search_soundtracks(term: str, session: requests.Session) -> SearchResults:
-    """Search KHInsider for albums and songs matching a term.
-
-    The search endpoint may redirect straight to an album page when there is
-    an exact match; handle that by returning a single-album result.
-
-    Args:
-        term: Free-text search term.
-        session: Shared HTTP session.
-
-    Returns:
-        SearchResults with albums and song-title matches.
-
-    Raises:
-        SearchError: If the search fails or returns no parsable results.
-        NetworkError: If the request itself fails.
+    Attributes:
+        albums: Matches by album title.
+        songs: Matches by song title (each row still points at an album).
     """
-    try:
-        resp = session.get(
-            urljoin(BASE_URL, "search"),
-            params={"search": term},
-            timeout=30,
-            allow_redirects=True,
-        )
-        resp.raise_for_status()
-    except requests.RequestException as e:
-        raise NetworkError(f"Failed to search for '{term}': {str(e)}") from e
 
-    # If we were redirected directly to an album page, return that album.
-    path = urlsplit(resp.url).path
-    if path.startswith("/game-soundtracks/album/"):
-        ost_id = path.rstrip("/").rsplit("/", 1)[-1]
-        return SearchResults(albums=[Soundtrack(ost_id, session)], songs=[])
+    albums: Tuple[AlbumSummary, ...]
+    songs: Tuple[AlbumSummary, ...]
 
-    soup = _soup_from_bytes(resp.content)
 
-    tables = soup.find_all("table", class_="albumList")
-    if not tables:
-        # Typical page contains a <p> with a human message.
-        message_tag = soup.find("p")
-        message = message_tag.get_text(strip=True) if message_tag else ""
-        raise SearchError(message or "No results returned.")
+# ==============================================================================
+# Layer 2 - Infrastructure: KHInsiderClient
+# ==============================================================================
 
-    def _parse_table(table: BeautifulSoup) -> List[Soundtrack]:
-        """Parse one albumList table into Soundtrack stubs.
 
-        We assign the discovered name directly to avoid extra requests when
-        printing results later.
+class KHInsiderClient:
+    """Reads KHInsider's HTML and produces immutable domain entities.
+
+    All ``requests`` and ``BeautifulSoup`` knowledge lives here. The rest
+    of the application talks only to the entities returned by this class.
+
+    Attributes:
+        session: The HTTP session used for every fetch. Caller-owned.
+        timeout: Per-request timeout in seconds.
+        prefetch_workers: Maximum parallel song-page fetches inside
+            :meth:`get_album`.
+    """
+
+    def __init__(
+        self,
+        session: "_curl_requests.Session",
+        timeout: float = DEFAULT_TIMEOUT,
+        prefetch_workers: int = PREFETCH_WORKERS,
+    ):
+        self.session = session
+        self.timeout = timeout
+        self.prefetch_workers = prefetch_workers
+
+    # --- public API ---------------------------------------------------------
+
+    def fetch_album_metadata(
+        self, album_id_or_url: str
+    ) -> "_AlbumMetadata":
+        """Fetch and parse only the album page.
+
+        The returned :class:`_AlbumMetadata` carries a partial
+        :class:`Album` (with empty :attr:`Track.files`) plus the track-
+        detail links needed to fill them in. Pair with
+        :meth:`prefetch_track_files` to get a fully-populated album.
+
+        The two-phase API exists so the CLI can print its banner
+        between the (fast) album-page fetch and the (slow) parallel
+        track-detail prefetch — matching the legacy verbose UX.
+
+        Args:
+            album_id_or_url: An album ID slug or a full album URL.
+
+        Returns:
+            An :class:`_AlbumMetadata` carrying the partial album and
+            the parallel track-detail link list.
+
+        Raises:
+            InvalidSoundtrackError: If the album page is missing or 404s.
+            NetworkError: If the fetch fails after retries.
         """
-        rows = table.find_all("tr")[1:]  # skip header row
-        found: List[Soundtrack] = []
-        for tr in rows:
-            tds = tr.find_all("td")  # type: ignore
+        album_id, given_url = _extract_id_and_url(album_id_or_url)
+        url = given_url or urljoin(
+            BASE_URL, f"game-soundtracks/album/{album_id}"
+        )
+        soup = _get_soup(url, self.session, self.timeout)
+
+        if soup.find(string="No such album"):
+            raise InvalidSoundtrackError(f"Album not found: {album_id}")
+
+        name = self._parse_album_name(soup, url)
+        formats = self._parse_album_formats(soup)
+        track_links = self._parse_track_links(soup, base_url=url)
+        images = self._parse_album_images(soup, base_url=url)
+
+        skeleton_tracks = tuple(
+            Track(name=display_name, files=())
+            for display_name, _ in track_links
+        )
+        album = Album(
+            id=album_id,
+            name=name,
+            url=url,
+            formats=tuple(formats),
+            tracks=skeleton_tracks,
+            images=tuple(images),
+        )
+        return _AlbumMetadata(album=album, track_links=tuple(track_links))
+
+    def prefetch_track_files(
+        self,
+        metadata: "_AlbumMetadata",
+        verbose: bool = False,
+    ) -> Album:
+        """Populate every track's ``files`` field via parallel fetches.
+
+        Returns a new :class:`Album` (since :class:`Album` is frozen)
+        with the track file lists filled in. Per-track failures are
+        tolerated: the offending track keeps ``files=()`` and surfaces
+        a clearer error if the user later tries to download it.
+
+        Args:
+            metadata: The album metadata returned by
+                :meth:`fetch_album_metadata`.
+            verbose: If True, print
+                ``"Prefetching metadata for N tracks... Done."``
+                (single-track albums skip this banner) and a stderr
+                "Note:" line if any track-detail page failed.
+
+        Returns:
+            A new :class:`Album` with populated track files.
+        """
+        tracks = self._fetch_tracks(
+            list(metadata.track_links), verbose=verbose
+        )
+        album = metadata.album
+        return Album(
+            id=album.id,
+            name=album.name,
+            url=album.url,
+            formats=album.formats,
+            tracks=tuple(tracks),
+            images=album.images,
+        )
+
+    def get_album(
+        self,
+        album_id_or_url: str,
+        verbose_prefetch: bool = False,
+    ) -> Album:
+        """Convenience: fetch metadata and prefetch all track files.
+
+        Equivalent to :meth:`fetch_album_metadata` followed by
+        :meth:`prefetch_track_files`. Intended for non-CLI callers that
+        want a single fully-resolved :class:`Album`. The CLI uses the
+        two-phase form so it can print its banner between them.
+
+        Args:
+            album_id_or_url: An album ID slug or a full album URL.
+            verbose_prefetch: Forwarded to :meth:`prefetch_track_files`.
+
+        Returns:
+            A fully-populated :class:`Album`.
+
+        Raises:
+            InvalidSoundtrackError: If the album page is missing or 404s.
+            NetworkError: If the initial fetch fails after retries.
+        """
+        metadata = self.fetch_album_metadata(album_id_or_url)
+        return self.prefetch_track_files(
+            metadata, verbose=verbose_prefetch
+        )
+
+    def search(self, term: str) -> SearchResults:
+        """Search KHInsider for albums and songs matching a term.
+
+        The search endpoint may redirect straight to an album page when
+        there is an exact match; in that case a single-row
+        ``SearchResults.albums`` is returned (with an empty name — call
+        :meth:`resolve_summary_names` if you need it).
+
+        Args:
+            term: Free-text search term.
+
+        Returns:
+            :class:`SearchResults` populated with :class:`AlbumSummary`
+            rows.
+
+        Raises:
+            NetworkError: If the request itself fails.
+            SearchError: If the response is unparseable or empty.
+        """
+        try:
+            resp = self.session.get(
+                urljoin(BASE_URL, "search"),
+                params={"search": term},
+                timeout=self.timeout,
+                allow_redirects=True,
+            )
+            resp.raise_for_status()
+        except _NETWORK_EXCEPTIONS as exc:
+            raise NetworkError(
+                f"Failed to search for '{term}': {exc}"
+            ) from exc
+
+        path = urlsplit(resp.url).path
+        if path.startswith("/game-soundtracks/album/"):
+            ost_id = path.rstrip("/").rsplit("/", 1)[-1]
+            return SearchResults(
+                albums=(
+                    AlbumSummary(id=ost_id, name="", url=resp.url),
+                ),
+                songs=(),
+            )
+
+        soup = _soup_from_bytes(resp.content)
+        tables = soup.find_all("table", class_="albumList")
+        if not tables:
+            message_tag = soup.find("p")
+            message = (
+                message_tag.get_text(strip=True) if message_tag else ""
+            )
+            raise SearchError(message or "No results returned.")
+
+        parsed = [self._parse_search_table(t) for t in tables]
+        if len(parsed) == 1:
+            text = ""
+            page_section = soup.find(id="pageContent")
+            if page_section is not None:
+                first_p = page_section.find("p")
+                if first_p is not None:
+                    text = first_p.get_text(strip=True)
+            if "song" in text.lower():
+                return SearchResults(albums=(), songs=parsed[0])
+            return SearchResults(albums=parsed[0], songs=())
+
+        return SearchResults(albums=parsed[0], songs=parsed[1])
+
+    def resolve_summary_names(
+        self,
+        summaries: Sequence[AlbumSummary],
+    ) -> Tuple[AlbumSummary, ...]:
+        """Concurrently fill in missing names on the given summaries.
+
+        Each summary whose ``name`` is empty triggers a fetch of its
+        album page to extract the title. Existing names are kept. Per-
+        summary failures are swallowed (the row keeps an empty name and
+        callers fall back to displaying the ID).
+
+        Args:
+            summaries: Search rows in any state.
+
+        Returns:
+            A new tuple of :class:`AlbumSummary` objects in input order.
+        """
+        resolved: List[AlbumSummary] = list(summaries)
+        needs = [
+            (i, s) for i, s in enumerate(resolved) if not s.name
+        ]
+        if not needs:
+            return tuple(resolved)
+
+        def _fetch_name(
+            indexed: Tuple[int, AlbumSummary],
+        ) -> Tuple[int, Optional[str]]:
+            index, summary = indexed
+            try:
+                soup = _get_soup(summary.url, self.session, self.timeout)
+                name_tag = soup.find("h2")
+                if name_tag is None:
+                    return index, None
+                return index, sanitize_filename(
+                    name_tag.get_text(strip=True)
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                return index, None
+
+        from concurrent.futures import ThreadPoolExecutor
+        workers = min(SEARCH_PREFETCH_WORKERS, len(needs))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            for index, name in executor.map(_fetch_name, needs):
+                if name:
+                    summary = resolved[index]
+                    resolved[index] = AlbumSummary(
+                        id=summary.id,
+                        name=name,
+                        url=summary.url,
+                    )
+        return tuple(resolved)
+
+    # --- private parsers ----------------------------------------------------
+
+    @staticmethod
+    def _parse_album_name(soup: "BeautifulSoup", url: str) -> str:
+        """Return the sanitized album title from the album page soup."""
+        name_tag = soup.find("h2")
+        if name_tag is None:
+            raise InvalidSoundtrackError(f"Album page invalid: {url}")
+        return sanitize_filename(name_tag.get_text(strip=True))
+
+    @staticmethod
+    def _parse_album_formats(soup: "BeautifulSoup") -> List[str]:
+        """Return the audio formats present in the songlist column headers.
+
+        Column headers are intersected with :data:`_KNOWN_AUDIO_FORMATS`
+        so unrelated columns (``length``, ``artist``) are not mistaken
+        for formats. Defaults to ``["mp3"]`` when no songlist is found.
+        """
+        table = soup.find("table", id="songlist")
+        if table is None:
+            return ["mp3"]
+        headers = [
+            th.get_text(strip=True).lower()
+            for th in table.find_all("th")
+        ]
+        return [h for h in headers if h in _KNOWN_AUDIO_FORMATS] or ["mp3"]
+
+    @staticmethod
+    def _parse_track_links(
+        soup: "BeautifulSoup", base_url: str
+    ) -> List[Tuple[str, str]]:
+        """Return ``[(display_name, absolute_url), ...]`` for songlist rows."""
+        table = soup.find("table", id="songlist")
+        if table is None:
+            return []
+        out: List[Tuple[str, str]] = []
+        for row in table.find_all("tr"):
+            anchor = row.find("a")
+            if anchor is None or not anchor.get("href"):
+                continue
+            display_name = anchor.get_text(strip=True)
+            out.append(
+                (display_name, urljoin(base_url, str(anchor["href"])))
+            )
+        return out
+
+    @staticmethod
+    def _parse_album_images(
+        soup: "BeautifulSoup", base_url: str
+    ) -> List[MediaFile]:
+        """Return the images linked from the album page (excluding songlist).
+
+        Scans every table on the album page (skipping the songlist) for
+        anchors whose ``href`` points at an image and whose body
+        contains an ``<img>`` thumbnail.
+        """
+        out: List[MediaFile] = []
+        seen: set = set()
+        for table in soup.find_all("table"):
+            if table.get("id") == "songlist":
+                continue
+            for anchor in table.find_all("a"):
+                href = anchor.get("href")
+                if not href or href in seen:
+                    continue
+                if anchor.find("img") is None:
+                    continue
+                seen.add(href)
+                out.append(
+                    MediaFile.from_url(urljoin(base_url, str(href)))
+                )
+        return out
+
+    def _fetch_tracks(
+        self,
+        track_links: List[Tuple[str, str]],
+        verbose: bool = False,
+    ) -> List[Track]:
+        """Concurrently fetch every track-detail page.
+
+        Per-track failures are tolerated (the track is returned with
+        ``files=()``) so a single broken page doesn't kill the whole
+        album fetch. The download path will surface a clearer error if
+        the user later tries to download such a track.
+
+        Args:
+            track_links: ``(display_name, detail_url)`` pairs to fetch.
+            verbose: If True, emit a single stderr "Note:" line when
+                any per-track fetch failed. The wrapping
+                "Prefetching..." progress banner is the CLI's
+                responsibility, not the client's.
+        """
+        if not track_links:
+            return []
+
+        results: List[Optional[Track]] = [None] * len(track_links)
+        failures = 0
+        failures_lock = threading.Lock()
+
+        def _fetch(indexed: Tuple[int, Tuple[str, str]]) -> None:
+            nonlocal failures
+            index, (display_name, url) = indexed
+            try:
+                files = self._fetch_track_files(url)
+                results[index] = Track(
+                    name=display_name, files=tuple(files)
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                results[index] = Track(name=display_name, files=())
+                with failures_lock:
+                    failures += 1
+
+        from concurrent.futures import ThreadPoolExecutor
+        workers = min(self.prefetch_workers, len(track_links))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            list(executor.map(_fetch, list(enumerate(track_links))))
+
+        if verbose and failures:
+            print(
+                f"Note: {failures} song(s) failed metadata prefetch and "
+                "will be retried during download.",
+                file=sys.stderr,
+            )
+
+        return [t for t in results if t is not None]
+
+    def _fetch_track_files(self, url: str) -> List[MediaFile]:
+        """Fetch a track-detail page and return its downloadable files.
+
+        Raises:
+            InvalidSoundtrackError: If the track page returns a 404-like
+                title.
+        """
+        soup = _get_soup(url, self.session, self.timeout)
+        title = soup.find("title")
+        title_text = title.get_text() if title is not None else ""
+        if "404" in title_text:
+            raise InvalidSoundtrackError(f"Track not found: {url}")
+
+        seen: List[str] = []
+        seen_set: set = set()
+        for anchor in soup.find_all("a", href=_TRACK_FILE_HREF_RE):
+            href = anchor.get("href")
+            if not href or href in seen_set:
+                continue
+            seen_set.add(href)
+            seen.append(str(href))
+        return [
+            MediaFile.from_url(urljoin(url, link)) for link in seen
+        ]
+
+    @staticmethod
+    def _parse_search_table(table: "Tag") -> Tuple[AlbumSummary, ...]:
+        """Parse one ``<table class="albumList">`` into AlbumSummary rows."""
+        rows = table.find_all("tr")[1:]  # skip header
+        out: List[AlbumSummary] = []
+        for row in rows:
+            tds = row.find_all("td")
             if len(tds) < 2:
                 continue
-            anchor = tds[1].find("a")  # type: ignore
-            if not anchor or not anchor.get("href"):  # type: ignore
+            anchor = tds[1].find("a")
+            if not anchor or not anchor.get("href"):
                 continue
-            album_id = anchor["href"].rstrip("/").rsplit("/", 1)[-1]  # type: ignore
-            name_text = anchor.get_text(strip=True)  # type: ignore
-            ost = Soundtrack(album_id, session)
-            # Pre-populate the cached name to avoid fetching each album page.
-            ost._name = sanitize_filename(name_text)
-            found.append(ost)
-        return found
-
-    parsed_tables = [_parse_table(t) for t in tables]  # type: ignore
-    if len(parsed_tables) == 1:
-        # If the page wording says it's song results, keep it in songs.
-        page_p = soup.find(id="pageContent")
-        text = (page_p.find("p").get_text(strip=True)  # type: ignore
-                if page_p and page_p.find("p") else "")  # type: ignore
-        if "song" in text.lower():
-            return SearchResults(albums=[], songs=parsed_tables[0])
-        return SearchResults(albums=parsed_tables[0], songs=[])
-
-    # Two tables: first albums, second songs.
-    albums = parsed_tables[0]
-    songs = parsed_tables[1] if len(parsed_tables) > 1 else []
-    return SearchResults(albums=albums, songs=songs)
+            href = str(anchor["href"])
+            album_id = href.rstrip("/").rsplit("/", 1)[-1]
+            display_name = anchor.get_text(strip=True)
+            url = urljoin(BASE_URL, f"game-soundtracks/album/{album_id}")
+            out.append(
+                AlbumSummary(
+                    id=album_id,
+                    name=(
+                        sanitize_filename(display_name)
+                        if display_name
+                        else ""
+                    ),
+                    url=url,
+                )
+            )
+        return tuple(out)
 
 
-def print_search_results(results: SearchResults, file=sys.stdout) -> None:
-    """Pretty-print search results, similar to the legacy script.
+# ==============================================================================
+# Layer 3 - Application: download services
+# ==============================================================================
 
-    Args:
-        results: Search outcome to print.
-        file: Target stream (stdout or stderr).
+
+class DownloadObserver(Protocol):
+    """The contract a presentation layer implements to follow downloads.
+
+    :class:`DownloadManager` calls these methods at every state
+    transition. Implementations should be cheap (the manager calls
+    :meth:`on_progress` per chunk) and thread-safe when callers schedule
+    parallel downloads through a thread pool.
     """
-    all_items = results.albums + results.songs
-    if not all_items:
-        print("No soundtracks found.", file=file)
-        return
 
-    pad = max((len(ost.id) for ost in all_items), default=0)
+    def on_skip(self, filename: str) -> None:
+        """Called when the destination already exists and force is False."""
 
-    def _print_group(title: str, items: List[Soundtrack]) -> None:
-        if not items:
+    def on_start(
+        self, filename: str, total_bytes: Optional[int]
+    ) -> None:
+        """Called once at the start of each transfer attempt.
+
+        ``total_bytes`` is ``None`` when the server did not send a
+        usable ``Content-Length`` (e.g., chunked transfer encoding).
+        """
+
+    def on_progress(self, delta_bytes: int) -> None:
+        """Called for each chunk written. ``delta_bytes`` is positive."""
+
+    def on_retry(
+        self,
+        filename: str,
+        attempt: int,
+        max_attempts: int,
+        error: BaseException,
+        backoff_seconds: float,
+    ) -> None:
+        """Called when a transient failure schedules a backoff retry."""
+
+    def on_complete(
+        self,
+        filename: str,
+        success: bool,
+        error: Optional[BaseException],
+        attempts: int,
+    ) -> None:
+        """Called once per file at the terminal state.
+
+        ``attempts`` is the number of transfer attempts actually made
+        (1 on the happy path, ``max_retries`` after retry exhaustion).
+        Implementations can use it to distinguish a non-retryable
+        first-attempt failure from a retry-exhausted one.
+        """
+
+
+class _NullObserver:
+    """No-op :class:`DownloadObserver`. The default for non-CLI callers."""
+
+    def on_skip(self, filename: str) -> None:
+        del filename
+
+    def on_start(
+        self, filename: str, total_bytes: Optional[int]
+    ) -> None:
+        del filename, total_bytes
+
+    def on_progress(self, delta_bytes: int) -> None:
+        del delta_bytes
+
+    def on_retry(
+        self,
+        filename: str,
+        attempt: int,
+        max_attempts: int,
+        error: BaseException,
+        backoff_seconds: float,
+    ) -> None:
+        del filename, attempt, max_attempts, error, backoff_seconds
+
+    def on_complete(
+        self,
+        filename: str,
+        success: bool,
+        error: Optional[BaseException],
+        attempts: int,
+    ) -> None:
+        del filename, success, error, attempts
+
+
+class _DownloadOutcome(enum.Enum):
+    """Terminal state of a single :meth:`DownloadManager.download_file` call."""
+
+    DOWNLOADED = "downloaded"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+class DownloadManager:
+    """Atomic, retrying, UI-agnostic file downloader.
+
+    Streams the body of a :class:`MediaFile` to ``<dest>.part`` and
+    renames it to ``dest`` on success, so an interrupted run never
+    leaves a half-finished file at the final path. Transient failures
+    (network errors, server 5xx / 408 / 429, transient OS errors,
+    byte-count mismatch) trigger an exponential-backoff retry up to
+    :attr:`max_retries` total attempts. Non-transient failures abort
+    immediately.
+
+    All observable progress is reported through a
+    :class:`DownloadObserver` — the only seam the presentation layer
+    needs.
+
+    Attributes:
+        session: HTTP session used for streaming.
+        timeout: Per-request timeout in seconds.
+        max_retries: Maximum attempts per file (including the first).
+        chunk_size: Bytes per ``iter_content`` chunk.
+    """
+
+    def __init__(
+        self,
+        session: "_curl_requests.Session",
+        timeout: float = DEFAULT_TIMEOUT,
+        max_retries: int = MAX_RETRIES,
+        chunk_size: int = CHUNK_SIZE,
+    ):
+        self.session = session
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.chunk_size = chunk_size
+
+    def download_file(
+        self,
+        media: MediaFile,
+        dest: Path,
+        observer: Optional[DownloadObserver] = None,
+        force: bool = False,
+    ) -> Tuple[_DownloadOutcome, Optional[BaseException]]:
+        """Download a single :class:`MediaFile` to ``dest``.
+
+        Args:
+            media: Source file metadata.
+            dest: Destination path. Parent directory must already exist.
+            observer: Notification sink. Defaults to a no-op.
+            force: If True, overwrite an existing file at ``dest``. If
+                False and ``dest`` exists with size > 0, the download is
+                skipped (``observer.on_skip`` is invoked).
+
+        Returns:
+            A ``(outcome, error)`` tuple. ``error`` is ``None`` unless
+            the outcome is :attr:`_DownloadOutcome.FAILED`.
+        """
+        active_observer: DownloadObserver = observer or _NullObserver()
+
+        if not force and self._existing_is_complete(dest):
+            active_observer.on_skip(dest.name)
+            return _DownloadOutcome.SKIPPED, None
+
+        last_error: Optional[BaseException] = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                self._stream_to_disk(media, dest, active_observer)
+                active_observer.on_complete(
+                    dest.name, success=True, error=None, attempts=attempt,
+                )
+                return _DownloadOutcome.DOWNLOADED, None
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                if not self._is_retryable(exc):
+                    active_observer.on_complete(
+                        dest.name,
+                        success=False,
+                        error=exc,
+                        attempts=attempt,
+                    )
+                    return _DownloadOutcome.FAILED, exc
+                last_error = exc
+                if attempt >= self.max_retries:
+                    break
+                import random
+                backoff = (2 ** (attempt - 1)) + random.uniform(0, 0.5)
+                active_observer.on_retry(
+                    dest.name,
+                    attempt,
+                    self.max_retries,
+                    exc,
+                    backoff,
+                )
+                time.sleep(backoff)
+
+        active_observer.on_complete(
+            dest.name,
+            success=False,
+            error=last_error,
+            attempts=self.max_retries,
+        )
+        return _DownloadOutcome.FAILED, last_error
+
+    @staticmethod
+    def _existing_is_complete(dest: Path) -> bool:
+        """Return True if ``dest`` already exists with a non-zero size.
+
+        Treats an :class:`OSError` on stat as "exists" — matching the
+        legacy "if we can't tell, assume the file is fine" behavior so
+        we never re-download something we couldn't even stat.
+        """
+        if not dest.exists():
+            return False
+        try:
+            return dest.stat().st_size > 0
+        except OSError:
+            return True
+
+    def _stream_to_disk(
+        self,
+        media: MediaFile,
+        dest: Path,
+        observer: DownloadObserver,
+    ) -> None:
+        """Atomic streaming write. Cleans up the .part file on any failure.
+
+        Bytes are written to ``<dest>.part`` and then renamed to
+        ``dest`` on success, so a half-finished or interrupted download
+        never leaves a file at the final path. Any partial ``.part``
+        file is removed on failure (including ``KeyboardInterrupt``).
+
+        Raises:
+            requests.RequestException / curl_cffi RequestException: On
+                network error. The caller's retry loop catches both via
+                :data:`_NETWORK_EXCEPTIONS`.
+            IncompleteDownloadError: If the response advertised an
+                un-encoded ``Content-Length`` and the bytes written did
+                not match. Skipped on encoded responses (where the
+                header reflects compressed bytes but ``iter_content``
+                yields decoded bytes).
+        """
+        tmp = dest.with_suffix(dest.suffix + ".part")
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+        try:
+            resp = self.session.get(
+                media.url, stream=True, timeout=self.timeout
+            )
+            resp.raise_for_status()
+
+            total: Optional[int] = None
+            length = resp.headers.get("Content-Length")
+            if length and length.isdigit():
+                total = int(length)
+
+            content_encoding = resp.headers.get(
+                "Content-Encoding", ""
+            ).lower()
+            verify_size = total is not None and not content_encoding
+
+            observer.on_start(dest.name, total)
+
+            written = 0
+            with tmp.open("wb") as f:
+                for chunk in resp.iter_content(
+                    chunk_size=self.chunk_size
+                ):
+                    if not chunk:
+                        continue
+                    f.write(chunk)
+                    written += len(chunk)
+                    observer.on_progress(len(chunk))
+
+            if verify_size and written != total:
+                raise IncompleteDownloadError(
+                    f"Expected {total} bytes for {media.filename!r}, "
+                    f"got {written}"
+                )
+
+            os.replace(tmp, dest)
+        except BaseException:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _is_retryable(exc: BaseException) -> bool:
+        """Return True if ``exc`` represents a transient failure.
+
+        This decides whether a *whole-file* retry is worth doing. libcurl
+        (via curl_cffi) handles socket-level retries inside a single
+        ``session.get`` call on its own, so by the time an exception
+        reaches here it has already survived that layer.
+        """
+        if isinstance(exc, IncompleteDownloadError):
+            return True
+        if isinstance(exc, _HTTP_EXCEPTIONS):
+            resp = getattr(exc, "response", None)
+            if resp is None:
+                return True
+            status = resp.status_code
+            if 400 <= status < 500:
+                return status in _RETRYABLE_4XX_STATUSES
+            return True  # 5xx
+        if isinstance(exc, _NETWORK_EXCEPTIONS):
+            return True  # connect/read/timeout/SSL/etc.
+        if isinstance(exc, OSError):
+            return exc.errno in _TRANSIENT_OSERROR_ERRNOS
+        return False
+
+
+@dataclass
+class DownloadReport:
+    """Mutable, thread-safe accumulator for per-file download outcomes.
+
+    Used by :class:`DownloadOrchestrator` to support an end-of-run
+    summary instead of forcing the caller to scrape stderr to learn
+    what failed.
+
+    Attributes:
+        succeeded: Number of files successfully downloaded.
+        skipped: Number of files skipped because they already existed
+            on disk and ``--force`` was not set.
+        failures: Per-file failure messages, in the form
+            ``"<filename>: <reason>"``.
+    """
+
+    succeeded: int = 0
+    skipped: int = 0
+    failures: List[str] = field(default_factory=list)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False
+    )
+
+    @property
+    def success(self) -> bool:
+        """Return True when no file failed."""
+        return not self.failures
+
+    def record_success(self, was_skipped: bool = False) -> None:
+        """Record a successful (or skipped) file."""
+        with self._lock:
+            if was_skipped:
+                self.skipped += 1
+            else:
+                self.succeeded += 1
+
+    def record_failure(self, name: str, reason: str) -> None:
+        """Record a failed file together with a brief reason string."""
+        with self._lock:
+            self.failures.append(f"{name}: {reason}")
+
+
+# ==============================================================================
+# Layer 4 - Presentation: observers and orchestration
+# ==============================================================================
+
+
+class _CliObserverBase:
+    """Shared base for CLI observers.
+
+    Provides label/prefix bookkeeping and the failure-message logic
+    shared by both the in-place progress-bar mode and the one-line
+    summary mode.
+
+    Attributes:
+        row_prefix: Pre-formatted ``"[N/M] "`` prefix used for status
+            lines (with an optional ``"image "`` infix).
+        max_retries: How many retry attempts the manager will make;
+            used to produce the legacy "after N attempts" failure line.
+        verbose: Whether informational lines are printed at all. Failure
+            lines are printed regardless of this flag.
+    """
+
+    def __init__(
+        self,
+        row_prefix: str,
+        max_retries: int,
+        verbose: bool,
+    ):
+        self.row_prefix = row_prefix
+        self.max_retries = max_retries
+        self.verbose = verbose
+
+    def on_skip(self, filename: str) -> None:
+        if self.verbose:
+            print(
+                f"{self.row_prefix}Skipping existing: {filename}"
+            )
+
+    def on_retry(
+        self,
+        filename: str,
+        attempt: int,
+        max_attempts: int,
+        error: BaseException,
+        backoff_seconds: float,
+    ) -> None:
+        if self.verbose:
+            print(
+                f"Retry {attempt}/{max_attempts} for {filename} in "
+                f"{backoff_seconds:.1f}s "
+                f"({error.__class__.__name__}: {error})",
+                file=sys.stderr,
+            )
+
+    def _print_failure(
+        self,
+        filename: str,
+        error: Optional[BaseException],
+        attempts: int,
+    ) -> None:
+        """Print the appropriate stderr failure line for the given mode.
+
+        Mirrors the legacy two-message split:
+          * Retry-exhausted (``attempts >= max_retries``):
+            ``Failed: <name> after <N> attempts: <reason>``.
+          * Non-retryable first-attempt failure:
+            ``[N/M] Error: <reason>``.
+        """
+        reason = (
+            f"{error.__class__.__name__}: {error}"
+            if error is not None
+            else "unknown"
+        )
+        if attempts >= self.max_retries:
+            print(
+                f"Failed: {filename} after {self.max_retries} "
+                f"attempts: {reason}",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"{self.row_prefix}Error: {reason}",
+                file=sys.stderr,
+            )
+
+
+class _OneLineObserver(_CliObserverBase):
+    """Prints one-line per-file status.
+
+    Used for non-TTY output, ``--no-verbose`` mode, or multi-threaded
+    downloads where a per-file progress bar would interleave
+    incoherently across files.
+    """
+
+    def __init__(
+        self,
+        row_prefix: str,
+        max_retries: int,
+        verbose: bool,
+    ):
+        super().__init__(row_prefix, max_retries, verbose)
+        self._bytes_written = 0
+
+    def on_start(
+        self, filename: str, total_bytes: Optional[int]
+    ) -> None:
+        del total_bytes
+        self._bytes_written = 0
+        if self.verbose:
+            display = _truncate_display_name(filename)
+            print(
+                f"{self.row_prefix}"
+                f"{display:<{_DISPLAY_NAME_WIDTH}} ..."
+            )
+
+    def on_progress(self, delta_bytes: int) -> None:
+        self._bytes_written += max(0, int(delta_bytes))
+
+    def on_retry(
+        self,
+        filename: str,
+        attempt: int,
+        max_attempts: int,
+        error: BaseException,
+        backoff_seconds: float,
+    ) -> None:
+        self._bytes_written = 0
+        super().on_retry(
+            filename, attempt, max_attempts, error, backoff_seconds
+        )
+
+    def on_complete(
+        self,
+        filename: str,
+        success: bool,
+        error: Optional[BaseException],
+        attempts: int,
+    ) -> None:
+        if success:
+            if self.verbose:
+                size = (
+                    _human_size(self._bytes_written)
+                    if self._bytes_written
+                    else "?"
+                )
+                print(
+                    f"{self.row_prefix}OK   {filename} ({size})"
+                )
             return
-        print(title, file=file)
-        for ost in items:
-            dots = "." * (pad - len(ost.id) + 1)
-            # ost.name is often pre-populated; if not, it will fetch lazily.
-            print(f"{ost.id} {dots} {ost.name}", file=file)
-        print("", file=file)
-
-    _print_group("Album title results:", results.albums)
-    _print_group("Song name results:", results.songs)
+        self._print_failure(filename, error, attempts)
 
 
-# ------------------------------------------------------------------------------
-# Main Entry Point
-# ------------------------------------------------------------------------------
+class CLIProgressObserver(_CliObserverBase):
+    """In-place per-file progress bar (single-thread + TTY + verbose).
 
-def main() -> None:
-    """Parse CLI args, configure session, and download the soundtrack."""
+    Wraps the module-private :class:`_ProgressBar` widget. The bar is
+    created in :meth:`on_start` and recreated on each retry so the
+    user sees a fresh bar per attempt — matching the legacy behavior.
+    """
+
+    def __init__(self, row_prefix: str, max_retries: int):
+        super().__init__(row_prefix, max_retries, verbose=True)
+        self._bar: Optional[_ProgressBar] = None
+
+    def on_start(
+        self, filename: str, total_bytes: Optional[int]
+    ) -> None:
+        display = _truncate_display_name(filename)
+        label = f"{self.row_prefix}{display:<{_DISPLAY_NAME_WIDTH}}"
+        self._bar = _ProgressBar(prefix=label, total=total_bytes)
+        self._bar(0, total_bytes)
+
+    def on_progress(self, delta_bytes: int) -> None:
+        if self._bar is not None:
+            self._bar(delta_bytes)
+
+    def on_retry(
+        self,
+        filename: str,
+        attempt: int,
+        max_attempts: int,
+        error: BaseException,
+        backoff_seconds: float,
+    ) -> None:
+        if self._bar is not None:
+            self._bar.close()
+            self._bar = None
+        super().on_retry(
+            filename, attempt, max_attempts, error, backoff_seconds
+        )
+
+    def on_complete(
+        self,
+        filename: str,
+        success: bool,
+        error: Optional[BaseException],
+        attempts: int,
+    ) -> None:
+        if self._bar is not None:
+            self._bar.close()
+            self._bar = None
+        if not success:
+            self._print_failure(filename, error, attempts)
+
+
+def _make_cli_observer(
+    row_prefix: str,
+    max_retries: int,
+    verbose: bool,
+    threads: int,
+) -> DownloadObserver:
+    """Pick the right CLI observer for the given mode.
+
+    The bar mode requires verbose output, a single thread (so frames
+    don't interleave between files), and a TTY (``isatty()``). All
+    other combinations fall back to the one-line observer.
+    """
+    if verbose and threads <= 1 and sys.stdout.isatty():
+        return CLIProgressObserver(row_prefix, max_retries)
+    return _OneLineObserver(row_prefix, max_retries, verbose=verbose)
+
+
+_DownloadJob = Tuple[str, Optional[MediaFile], Optional[BaseException]]
+
+
+class DownloadOrchestrator:
+    """Runs an :class:`Album` through a :class:`DownloadManager`.
+
+    Owns format selection, output-directory creation, threading, the
+    inter-file delay, the verbose banner, and the per-file observer
+    construction. Failures are recorded into a :class:`DownloadReport`
+    instead of being raised, so the caller always gets a complete
+    summary for the end-of-run message.
+
+    Attributes:
+        manager: The download backend.
+        observer_factory: Callable producing one observer per file. By
+            default, :func:`_make_cli_observer` is used; tests or
+            alternative front-ends can pass their own factory.
+    """
+
+    def __init__(
+        self,
+        manager: DownloadManager,
+        observer_factory: Optional[
+            Callable[[str, int, bool, int], DownloadObserver]
+        ] = None,
+    ):
+        self.manager = manager
+        self.observer_factory = observer_factory or _make_cli_observer
+
+    def run(
+        self,
+        album: Album,
+        output_dir: Path,
+        formats: Sequence[str],
+        download_images: bool,
+        threads: int,
+        delay: float,
+        force: bool,
+        verbose: bool,
+    ) -> DownloadReport:
+        """Download an album's tracks, then optionally its images.
+
+        The download banner is the *caller's* responsibility — the
+        orchestrator owns only the per-file progress observers, the
+        threading, and the failure tally. This separation keeps the
+        orchestrator from needing to know whether the banner has
+        already been printed by an upstream handler (which it has,
+        in the CLI flow, so the banner can land before the parallel
+        track-prefetch step).
+
+        Args:
+            album: A fully-resolved :class:`Album`.
+            output_dir: Directory to save tracks (and images) into.
+            formats: Preferred audio formats in priority order. Already
+                normalized (lowercase, stripped) by the CLI parser.
+                May be empty to mean "auto / best available".
+            download_images: If True, also download album images.
+            threads: Maximum concurrent file downloads. ``1`` keeps the
+                familiar in-place progress bar; values >1 disable the
+                per-file bar in favor of one-line completion messages.
+            delay: Seconds to wait between consecutive sequential
+                downloads (ignored when ``threads > 1``).
+            force: If True, overwrite files already on disk instead of
+                skipping them.
+            verbose: If True, the per-file observer prints status
+                lines. Failure lines print regardless.
+
+        Returns:
+            A :class:`DownloadReport` summarising successes, skips, and
+            per-file failure messages.
+
+        Raises:
+            InvalidFormatError: If no requested format is available.
+            OSError: If output directory creation fails.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        if formats and not set(formats).intersection(album.formats):
+            available = ", ".join(album.formats)
+            raise InvalidFormatError(
+                f"None of the requested formats {list(formats)} are "
+                f"available. Available: {available}"
+            )
+
+        report = DownloadReport()
+
+        track_jobs = self._build_track_jobs(album, formats)
+        self._run_jobs(
+            track_jobs,
+            output_dir,
+            threads=threads,
+            delay=delay,
+            force=force,
+            verbose=verbose,
+            report=report,
+            kind="track",
+        )
+
+        if download_images:
+            image_jobs = self._build_image_jobs(album)
+            self._run_jobs(
+                image_jobs,
+                output_dir,
+                threads=threads,
+                delay=delay,
+                force=force,
+                verbose=verbose,
+                report=report,
+                kind="image",
+            )
+
+        return report
+
+    # --- job construction ---------------------------------------------------
+
+    @staticmethod
+    def _build_track_jobs(
+        album: Album, formats: Sequence[str]
+    ) -> List[_DownloadJob]:
+        """Resolve each track to its chosen :class:`MediaFile`."""
+        jobs: List[_DownloadJob] = []
+        for track in album.tracks:
+            try:
+                jobs.append((track.name, track.best_file(formats), None))
+            except InvalidSoundtrackError as exc:
+                jobs.append((track.name, None, exc))
+        return jobs
+
+    @staticmethod
+    def _build_image_jobs(album: Album) -> List[_DownloadJob]:
+        """Trivial passthrough: each image is already a downloadable file."""
+        return [(img.filename, img, None) for img in album.images]
+
+    # --- dispatching --------------------------------------------------------
+
+    def _run_jobs(
+        self,
+        jobs: List[_DownloadJob],
+        output_dir: Path,
+        threads: int,
+        delay: float,
+        force: bool,
+        verbose: bool,
+        report: DownloadReport,
+        kind: str,
+    ) -> None:
+        """Schedule jobs sequentially or via a thread pool."""
+        if not jobs:
+            return
+
+        total = len(jobs)
+        pad = max(1, len(str(total)))
+        label_prefix = "image " if kind == "image" else ""
+
+        def _do_one(idx: int, job: _DownloadJob) -> None:
+            display_name, media, build_error = job
+            row_prefix = (
+                f"[{label_prefix}{idx:0{pad}d}/{total}] "
+            )
+            if build_error is not None:
+                self._record_build_error(
+                    display_name, idx, kind, row_prefix, build_error,
+                    report,
+                )
+                return
+            self._download_one(
+                media,
+                output_dir,
+                row_prefix,
+                threads=threads,
+                verbose=verbose,
+                force=force,
+                report=report,
+            )
+
+        if threads <= 1:
+            for idx, job in enumerate(jobs, start=1):
+                _do_one(idx, job)
+                if delay > 0 and idx < total:
+                    time.sleep(delay)
+            return
+
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor(max_workers=threads) as executor:
+            futures = [
+                executor.submit(_do_one, idx, job)
+                for idx, job in enumerate(jobs, start=1)
+            ]
+            for future in as_completed(futures):
+                future.result()
+
+    def _download_one(
+        self,
+        media: Optional[MediaFile],
+        output_dir: Path,
+        row_prefix: str,
+        threads: int,
+        verbose: bool,
+        force: bool,
+        report: DownloadReport,
+    ) -> None:
+        """Run one download through the manager and record the outcome."""
+        assert media is not None
+
+        dest = output_dir / sanitize_filename(media.filename)
+        observer = self.observer_factory(
+            row_prefix, self.manager.max_retries, verbose, threads,
+        )
+        outcome, error = self.manager.download_file(
+            media=media,
+            dest=dest,
+            observer=observer,
+            force=force,
+        )
+
+        if outcome is _DownloadOutcome.SKIPPED:
+            report.record_success(was_skipped=True)
+        elif outcome is _DownloadOutcome.DOWNLOADED:
+            report.record_success(was_skipped=False)
+        else:
+            reason = (
+                f"{error.__class__.__name__}: {error}"
+                if error is not None
+                else "unknown"
+            )
+            report.record_failure(dest.name, reason)
+
+    @staticmethod
+    def _record_build_error(
+        display_name: str,
+        idx: int,
+        kind: str,
+        row_prefix: str,
+        error: BaseException,
+        report: DownloadReport,
+    ) -> None:
+        """Record a job that failed before any HTTP request was made."""
+        name = display_name or f"{kind} #{idx}"
+        reason = f"{error.__class__.__name__}: {error}"
+        report.record_failure(name, reason)
+        print(
+            f"{row_prefix}Error: {reason}",
+            file=sys.stderr,
+        )
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# CLI helpers
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def _print_download_banner(
+    album: Album,
+    output_dir: Path,
+    formats: Sequence[str],
+    download_images: bool,
+    threads: int,
+) -> None:
+    """Render the verbose pre-download header block.
+
+    The "Processing:" / "Metadata: Fetching..." preamble is printed by
+    the CLI handler around the album-page fetch (see
+    :func:`_handle_download`); this helper owns the part of the banner
+    that depends on a fetched :class:`Album`.
+    """
+    print(f"Album:      {album.name}")
+    print(f"Output:     {output_dir.resolve()}")
+    print(
+        "Formats:    "
+        + (
+            ", ".join(formats)
+            if formats
+            else "Auto (Best Available)"
+        )
+    )
+    total_tracks = len(album.tracks)
+    print(f"Threads:    {threads}")
+    print(f"Content:    {total_tracks} Songs", end="")
+    if download_images:
+        print(f", {len(album.images)} Images")
+    else:
+        print()
+    print("-" * 50)
+
+
+def _parse_formats(raw: Optional[str]) -> Optional[List[str]]:
+    """Normalize the --format CLI argument.
+
+    ``"FLAC, mp3 ,, ogg"`` becomes ``["flac", "mp3", "ogg"]``. Returns
+    ``None`` when no formats were requested so the default-priority
+    logic in :meth:`Track.best_file` can take over.
+    """
+    if not raw:
+        return None
+    formats = [token.strip().lower() for token in raw.split(",")]
+    formats = [token for token in formats if token]
+    return formats or None
+
+
+def _bounded_int(low: int, high: int) -> Callable[[str], int]:
+    """Return an argparse ``type`` that enforces ``low <= n <= high``."""
+
+    def _check(value: str) -> int:
+        try:
+            n = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"expected integer, got {value!r}"
+            ) from exc
+        if not low <= n <= high:
+            raise argparse.ArgumentTypeError(
+                f"must be between {low} and {high}, got {n}"
+            )
+        return n
+
+    return _check
+
+
+def _non_negative_float(value: str) -> float:
+    """Argparse ``type`` for non-negative floats."""
+    import math
+    try:
+        f = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected number, got {value!r}"
+        ) from exc
+    if f < 0 or math.isnan(f):
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {f}")
+    return f
+
+
+def _positive_float(value: str) -> float:
+    """Argparse ``type`` for strictly positive floats."""
+    f = _non_negative_float(value)
+    if f <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {f}")
+    return f
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
-        description="Download KHInsider soundtracks (spoofing Chrome UA)",
+        description="Download KHInsider soundtracks",
         formatter_class=argparse.RawTextHelpFormatter,
-        epilog=f"Report issues: {REPORT_URL}"
+        epilog=f"Report issues: {REPORT_URL}",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument(
         "soundtrack",
         help=(
-            "Album ID from KHInsider URL\n"
+            "Album ID, full album URL, or search term (with -s)\n"
             "(e.g. 'kh2fm-soundtrack' from "
-            "https://downloads.khinsider.com/game-soundtracks/album/kh2fm-soundtrack)"
-        )
+            "https://downloads.khinsider.com/"
+            "game-soundtracks/album/kh2fm-soundtrack)"
+        ),
     )
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         type=Path,
-        help="Output directory (default: album name)"
+        help="Output directory (default: album name)",
     )
     parser.add_argument(
-        "-f", "--format",
-        help="Preferred audio formats, comma-separated (e.g. 'flac,mp3')"
+        "-f",
+        "--format",
+        help=(
+            "Preferred audio formats, comma-separated (e.g. 'flac,mp3'). "
+            "Case- and whitespace-insensitive."
+        ),
     )
     parser.add_argument(
-    "-i",
-    "--images",
-    action=argparse.BooleanOptionalAction,
-    default=True,
-    help="Download album images (default: enabled; use --no-images to disable).",
+        "-i",
+        "--images",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Download album images (default: enabled;"
+            " use --no-images to disable)."
+        ),
     )
     parser.add_argument(
-    "-v",
-    "--verbose",
-    action=argparse.BooleanOptionalAction,
-    default=True,
-    help="Show detailed progress (default: enabled; use --no-verbose to disable).",
+        "-v",
+        "--verbose",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Show detailed progress (default: enabled;"
+            " use --no-verbose to disable)."
+        ),
     )
     parser.add_argument(
-        "-s", "--search",
+        "-s",
+        "--search",
         action="store_true",
         help=(
             "Search for soundtracks instead of downloading. "
@@ -960,89 +2291,379 @@ def main() -> None:
             "does not exist."
         ),
     )
-    
+    parser.add_argument(
+        "-t",
+        "--threads",
+        type=_bounded_int(1, MAX_THREADS),
+        default=DEFAULT_THREADS,
+        metavar="N",
+        help=(
+            f"Concurrent file downloads (1-{MAX_THREADS}, default: "
+            f"{DEFAULT_THREADS}). Values >1 disable the per-file progress "
+            "bar in favor of one-line completion messages."
+        ),
+    )
+    parser.add_argument(
+        "-d",
+        "--delay",
+        type=_non_negative_float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "Seconds to wait between sequential downloads (default: 0). "
+            "Ignored when --threads > 1."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=DEFAULT_TIMEOUT,
+        metavar="SECONDS",
+        help=f"HTTP timeout in seconds (default: {DEFAULT_TIMEOUT}).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download files that already exist on disk.",
+    )
+    parser.add_argument(
+        "--list-only",
+        action="store_true",
+        dest="list_only",
+        help="Print what would be downloaded and exit (no files written).",
+    )
+    return parser
 
-    args = parser.parse_args()
+
+def _build_session(threads: int = DEFAULT_THREADS) -> "_curl_requests.Session":
+    """Construct an HTTP session that impersonates a real browser.
+
+    KHInsider is behind Cloudflare (I think), which rejects ``requests``
+    session with HTTP 403 because its TLS ClientHello and HTTP/2 SETTINGS
+    don't match any real browser. ``curl_cffi`` uses libcurl-impersonate
+    to replay Chrome's exact TLS/HTTP-2 fingerprint, which lets the
+    request through. Connection pooling and transient-error retries are
+    handled by libcurl internally and by the application-level
+    ``MAX_RETRIES`` loop in :class:`DownloadManager`; no urllib3-style
+    HTTPAdapter is required.
+    """
+    del threads  # accepted for call-site compatibility; not needed by libcurl
+    session = _curl_requests.Session(impersonate="chrome124")
+    session.headers.update(
+        {
+            "Referer": BASE_URL,
+            "Accept-Language": "en-US,en;q=0.9",
+        }
+    )
+    return session
+
+
+def _make_io_unicode_safe() -> None:
+    """Ensure stdout/stderr can encode any character KHInsider may emit.
+
+    On Windows, the default console encoding is often cp1252, which
+    raises ``UnicodeEncodeError`` on track titles containing non-Latin-1
+    characters (a frequent occurrence for Japanese game soundtracks).
+    Reconfiguring to UTF-8 with a replacement error handler keeps output
+    legible without crashing the process. ``reconfigure`` is a no-op on
+    streams that have already been redirected to a non-TextIOWrapper.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
+def _print_search_results(
+    results: SearchResults,
+    client: KHInsiderClient,
+    file=sys.stdout,
+    prefetch: bool = True,
+) -> None:
+    """Pretty-print search results.
+
+    By default, missing album names are pre-fetched in parallel before
+    printing so the user sees a complete list at once instead of waiting
+    for serial round-trips. Set ``prefetch=False`` to skip the warmup.
+    """
+    all_items: List[AlbumSummary] = (
+        list(results.albums) + list(results.songs)
+    )
+    if not all_items:
+        print("No soundtracks found.", file=file)
+        return
+
+    if prefetch:
+        all_items = list(client.resolve_summary_names(all_items))
+        album_count = len(results.albums)
+        results = SearchResults(
+            albums=tuple(all_items[:album_count]),
+            songs=tuple(all_items[album_count:]),
+        )
+
+    pad = max(len(item.id) for item in all_items)
+
+    def _print_group(title: str, items: Iterable[AlbumSummary]) -> None:
+        items_list = list(items)
+        if not items_list:
+            return
+        print(title, file=file)
+        for item in items_list:
+            display_name = item.name or "(name unavailable)"
+            dots = "." * (pad - len(item.id) + 1)
+            print(f"{item.id} {dots} {display_name}", file=file)
+        print("", file=file)
+
+    _print_group("Album title results:", results.albums)
+    _print_group("Song name results:", results.songs)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Entry and handlers
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def _print_failure_summary(report: DownloadReport) -> None:
+    """Render the end-of-run failure list to stderr."""
+    if not report.failures:
+        return
+    print(
+        f"\n{len(report.failures)} file(s) failed:",
+        file=sys.stderr,
+    )
+    for line in report.failures:
+        print(f"  - {line}", file=sys.stderr)
+
+
+def _handle_search(
+    args: argparse.Namespace, client: KHInsiderClient
+) -> int:
+    """Handle the ``--search`` mode."""
+    try:
+        results = client.search(args.soundtrack)
+    except (SearchError, NetworkError) as exc:
+        print(f"Search failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "Soundtracks found (to download, run "
+        '"python khinsider.py <soundtrack_id>"):\n'
+    )
+    _print_search_results(results, client)
+    return 0
+
+
+def _handle_list_only(
+    args: argparse.Namespace,
+    soundtrack_id: str,
+    user_input: str,
+    client: KHInsiderClient,
+) -> int:
+    """Handle the ``--list-only`` mode (preview without downloading)."""
+    formats = _parse_formats(args.format)
+    _, parsed_url = _extract_id_and_url(user_input)
+    try:
+        metadata = client.fetch_album_metadata(
+            parsed_url or soundtrack_id
+        )
+        album = client.prefetch_track_files(
+            metadata, verbose=args.verbose
+        )
+    except InvalidSoundtrackError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Album:   {album.name}")
+    print(f"Formats: {', '.join(album.formats)}")
+    print(f"\n{len(album.tracks)} track(s):")
+    for idx, track in enumerate(album.tracks, start=1):
+        try:
+            chosen = track.best_file(formats or [])
+            print(f"  [{idx:>3}] {chosen.filename}")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            print(
+                f"  [{idx:>3}] (error: {exc.__class__.__name__}: {exc})"
+            )
+    if args.images:
+        print(f"\n{len(album.images)} image(s):")
+        for idx, img in enumerate(album.images, start=1):
+            print(f"  [{idx:>3}] {img.filename}")
+    return 0
+
+
+def _handle_download(
+    args: argparse.Namespace,
+    soundtrack_id: str,
+    user_input: str,
+    client: KHInsiderClient,
+    orchestrator: DownloadOrchestrator,
+) -> int:
+    """Handle the default download mode.
+
+    Performs the fetch in two phases so the verbose banner can land
+    between the album-page fetch and the (slower) parallel track-detail
+    prefetch — matching the legacy progress-message ordering.
+    """
+    formats = _parse_formats(args.format)
+    _, parsed_url = _extract_id_and_url(user_input)
+
+    pre_fetch_announce = args.verbose and args.output is not None
+
+    if pre_fetch_announce:
+        print(f"Processing: {soundtrack_id}")
+        print(
+            "Metadata:   Fetching from KHInsider...",
+            end="",
+            flush=True,
+        )
+    try:
+        metadata = client.fetch_album_metadata(
+            parsed_url or soundtrack_id
+        )
+    except InvalidSoundtrackError:
+        if pre_fetch_announce:
+            print()
+        raise
+    if pre_fetch_announce:
+        print(" Done.")
+
+    out_dir = args.output or Path(metadata.album.name)
+
+    if args.verbose:
+        if not pre_fetch_announce:
+            print(f"Processing: {soundtrack_id}")
+        _print_download_banner(
+            metadata.album,
+            out_dir,
+            formats or [],
+            args.images,
+            args.threads,
+        )
+
+    if args.verbose and len(metadata.track_links) > 1:
+        print(
+            f"Prefetching metadata for {len(metadata.track_links)} "
+            "tracks...",
+            end="",
+            flush=True,
+        )
+    album = client.prefetch_track_files(metadata, verbose=args.verbose)
+    if args.verbose and len(metadata.track_links) > 1:
+        print(" Done.")
+
+    report = orchestrator.run(
+        album=album,
+        output_dir=out_dir,
+        formats=formats or [],
+        download_images=args.images,
+        threads=args.threads,
+        delay=args.delay,
+        force=args.force,
+        verbose=args.verbose,
+    )
+
+    _print_failure_summary(report)
+
+    if report.success:
+        print(
+            f"\nDownload completed successfully! "
+            f"({report.succeeded} downloaded, {report.skipped} skipped)"
+        )
+        return 0
+
+    print(
+        f"\nDownload completed with {len(report.failures)} error(s) "
+        f"({report.succeeded} downloaded, {report.skipped} skipped).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _handle_missing_album(
+    args: argparse.Namespace,
+    soundtrack_id: str,
+    client: KHInsiderClient,
+) -> int:
+    """Handle the auto-search fallback when an album ID isn't found."""
+    del args
+    search_term = soundtrack_id.replace("-", " ")
+    try:
+        results = client.search(search_term)
+    except (SearchError, NetworkError):
+        print(
+            f'The soundtrack "{soundtrack_id}" does not seem to exist, '
+            "and a search could not be performed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f'The soundtrack "{soundtrack_id}" does not seem to exist.\n',
+        file=sys.stderr,
+    )
+    print(
+        'These exist, though (run "python khinsider.py <soundtrack_id>"):',
+        file=sys.stderr,
+    )
+    _print_search_results(results, client, file=sys.stderr)
+    return 1
+
+
+def main() -> None:
+    """Parse CLI args, configure session, and dispatch the requested mode.
+
+    This function is the *composition root* — it owns the construction
+    and lifecycle of every layer's components and wires them together.
+    Everything below it is plain dependency injection.
+    """
+    _make_io_unicode_safe()
+    args = _build_arg_parser().parse_args()
 
     try:
-        with requests.Session() as session:
-            session.headers.update({
-                "User-Agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/114.0.0.0 Safari/537.36"
-                ),
-                "Referer": BASE_URL,
-            })
-
-            # Normalize possible full album URL to an ID.
+        with _build_session(threads=args.threads) as session:
+            client = KHInsiderClient(session, timeout=args.timeout)
             user_input = args.soundtrack
             soundtrack_id = extract_soundtrack_id(user_input)
 
-            # If explicitly asked to search, do that and exit.
             if args.search:
-                try:
-                    results = search_soundtracks(user_input, session)
-                except (SearchError, NetworkError) as e:
-                    print(f"Search failed: {e}", file=sys.stderr)
-                    sys.exit(1)
-                print(
-                    "Soundtracks found (to download, run "
-                    '"python khinsider.py <soundtrack_id>"):\n'
-                )
-                print_search_results(results)
-                sys.exit(0)
+                sys.exit(_handle_search(args, client))
 
-            # Otherwise, attempt normal download; on missing album, fall back to
-            # an automatic search using a friendlier term.
-            try:
-                ost = Soundtrack(soundtrack_id, session)
-                out_dir = args.output or Path(sanitize_filename(ost.name))
-
-                ok = ost.download(
-                    output_dir=out_dir,
-                    formats=args.format.split(",") if args.format else None,
-                    download_images=args.images,
-                    verbose=args.verbose,
-                )
-                if ok:
-                    print("\nDownload completed successfully!")
-                    sys.exit(0)
-                print("\nDownload completed with some errors.", file=sys.stderr)
-                sys.exit(1)
-
-            except InvalidSoundtrackError:
-                # Friendly automatic search, similar to legacy behavior.
-                search_term = user_input.replace("-", " ")
-                try:
-                    results = search_soundtracks(search_term, session)
-                except (SearchError, NetworkError):
-                    print(
-                        f'The soundtrack "{soundtrack_id}" does not seem to exist, '
-                        "and a search could not be performed.",
-                        file=sys.stderr,
+            if args.list_only:
+                sys.exit(
+                    _handle_list_only(
+                        args, soundtrack_id, user_input, client,
                     )
-                    sys.exit(1)
+                )
 
-                print(
-                    f'The soundtrack "{soundtrack_id}" does not seem to exist.\n',
-                    file=sys.stderr,
+            manager = DownloadManager(session, timeout=args.timeout)
+            orchestrator = DownloadOrchestrator(manager)
+
+            try:
+                sys.exit(
+                    _handle_download(
+                        args,
+                        soundtrack_id,
+                        user_input,
+                        client,
+                        orchestrator,
+                    )
                 )
-                print(
-                    'These exist, though (run "python khinsider.py <soundtrack_id>"):',
-                    file=sys.stderr,
+            except InvalidSoundtrackError:
+                sys.exit(
+                    _handle_missing_album(args, soundtrack_id, client)
                 )
-                print_search_results(results, file=sys.stderr)
-                sys.exit(1)
 
     except KeyboardInterrupt:
         print("\nDownload cancelled by user.", file=sys.stderr)
+        sys.exit(130)
+    except ScriptError as exc:
+        print(f"\nError: {exc}", file=sys.stderr)
         sys.exit(1)
-    except ScriptError as e:
-        print(f"\nError: {str(e)}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        print(f"\nUnexpected error: {str(e)}", file=sys.stderr)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        print(
+            f"\nUnexpected error: {exc.__class__.__name__}: {exc}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/readme.md
+++ b/readme.md
@@ -1,342 +1,112 @@
 # KHInsider Downloader
 
-A command-line and library interface for mass-downloading full game soundtracks (and optional album images) from [KHInsider](https://downloads.khinsider.com/). Built for Python 3.
+`khinsider.py` is a [Python](https://www.python.org/) interface and script for getting [khinsider](http://downloads.khinsider.com/) soundtracks. It makes khinsider mass downloads a breeze. It's easy to use, check it!
 
-> **New to Python?** If you’ve never used Python before, [click here](#never-used-python-before) to get started.
+> **Zero-setup:** Just run the script, it auto-installs dependencies!
+> Set `KHI_NO_AUTO_INSTALL=1` to disable auto-install.
+
+---
+
+## Quick Start
+
+```bash
+# Download by ID
+python khinsider.py plants-vs.-zombies
+
+# Download by full URL
+python khinsider.py https://downloads.khinsider.com/game-soundtracks/album/plants-vs.-zombies
+
+# Pick formats (first available is used)
+python khinsider.py minecraft -f flac,mp3
+
+# Search (or use automatically if an ID doesn’t exist)
+python khinsider.py -s persona
+python khinsider.py definitely-not-a-real-id   # auto-search fallback
+
+# Choose output directory
+python khinsider.py minecraft -o "Folder Where I Keep Minecraft Music"
+
+# Turn OFF images or verbose logging (defaults are ON)
+python khinsider.py minecraft --no-images
+python khinsider.py minecraft --no-verbose
+```
+
+---
+
+## CLI
+
+```bash
+python khinsider.py <album-id-or-url> [options]
+```
+
+**Options**
+
+* `-o, --output DIR` Output directory (default: sanitized album name)
+* `-f, --format LIST` Preferred formats, comma-separated (e.g. `flac,mp3`)
+* `-s, --search` Search for albums/songs instead of downloading
+* `-i/--no-images` Download album images (default **ON**)
+* `-v/--no-verbose` Detailed progress (default **ON**)
+* `-h, --help` Show help
 
 ---
 
 ## Features
 
-- Download entire soundtrack albums by ID or URL
-- Support for multiple audio formats (FLAC, MP3, etc.) with user-defined priority
-- **New**: Optional download of album images (cover art, booklet scans)
-- Automatic creation of sanitized output directories
-- HTTP connection reuse for performance
-- Retries on transient network failures
-- Comprehensive error reporting and exit codes
+* Download by **ID or full album URL**
+* Multi-format with priority (e.g., `flac,mp3`)
+* Album images (cover/booklet/etc.)
 
 ---
 
-## Requirements
+## “Never used Python before?”
 
-- Python 3.7+
-- [requests](https://pypi.org/project/requests) 2.31.0 or later
-- [beautifulsoup4](https://pypi.org/project/beautifulsoup4) 4.12.0 or later
-
-Install dependencies with:
+1. Install Python 3 from [https://www.python.org/downloads/](https://www.python.org/downloads/)
+2. Download this repo (or the single `khinsider.py` file)
+3. Run:
 
 ```bash
-pip install -r requirements.txt
-````
+python khinsider.py <album-id-or-url>
+```
+
+That’s it! The script installs what it needs automatically.
 
 ---
 
-## Installation
-
-Clone the repository or download the latest release ZIP:
-
-```bash
-git clone https://github.com/obskyr/khinsider.git
-cd khinsider
-```
-
-Ensure the script is executable:
-
-```bash
-chmod +x khinsider.py
-```
-
-Optionally, install into your `$PATH`:
-
-```bash
-pip install .
-```
-
----
-
-## Usage
-
-### Command-Line Interface
-
-```bash
-khinsider.py <album-id-or-url> [OPTIONS]
-```
-
-**Positional arguments**
-
-* `<album-id-or-url>`
-  The soundtrack identifier (e.g. `kh2fm-soundtrack`) or full URL.
-
-**Options**
-
-* `-o, --output DIR`
-  Output directory (default: sanitized album name).
-* `-f, --format FORMATS`
-  Comma-separated list of preferred audio formats, in priority order (e.g. `flac,mp3`).
-* `-i, --images`
-  Download album images (cover, booklet, etc.) in addition to audio.
-* `-v, --verbose`
-  Show detailed progress and retry messages.
-* `-h, --help`
-  Show usage information and exit.
-
-**Exit codes**
-
-* `0` All files downloaded successfully
-* `1` Completed with errors or unexpected exception
-* `2` Invalid arguments or help request
-
-#### Examples
-
-Download the **Aquaplus Vocal Collection Vol. 4** in FLAC:
-
-```bash
-khinsider.py aquaplus-vocal-collection-vol.4 -f flac
-```
-
-Download **Minecraft OST** in FLAC or MP3, plus album images, with verbose output:
-
-```bash
-khinsider.py minecraft -f flac,mp3 -i -v
-```
-
----
-
-### Library Interface
-
-Use the core classes directly in your own code:
+## Library
 
 ```python
 from pathlib import Path
 import requests
 from khinsider import Soundtrack
 
-# Create an HTTP session
-session = requests.Session()
-
-# Instantiate a Soundtrack by its ID (or URL segment)
-ost = Soundtrack("jumping-flash", session)
-
-# Download audio only (default formats)
-ost.download(
-    output_dir=Path("Jumping Flash OST"),
-    formats=None,
-    download_images=False,
-    verbose=True,
-)
-
-# Download only MP3s plus album images
-ost.download(
-    output_dir=Path("Mother 3 OST"),
-    formats=["mp3"],
-    download_images=True,
-    verbose=False,
-)
-````
-
-If you prefer a single‐function entry point, add this to your module:
-
-```python
-import requests
-from khinsider import Soundtrack
-from pathlib import Path
-from typing import List, Optional
-
-def download(
-    soundtrack_id: str,
-    output_dir: Path,
-    formats: Optional[List[str]] = None,
-    download_images: bool = False,
-    verbose: bool = False
-) -> bool:
-    """Convenience wrapper around Soundtrack.download()."""
-    session = requests.Session()
-    ost = Soundtrack(soundtrack_id, session)
-    return ost.download(output_dir, formats, download_images, verbose)
-```
-
-Then call:
-
-```python
-import khinsider
-from pathlib import Path
-
-khinsider.download(
-    "jumping-flash",
-    Path("Jumping Flash OST"),
-    formats=None,
-    download_images=False,
-    verbose=True,
-)
+with requests.Session() as s:
+    ost = Soundtrack("jumping-flash", s)  # or full URL
+    ost.download(
+        output_dir=Path("Jumping Flash OST"),
+        formats=["flac", "mp3"],
+        download_images=True,   # defaults True in CLI
+        verbose=True,           # defaults True in CLI
+    )
 ```
 
 ---
 
-### API
+## Optional: Manual Dependencies
 
-#### `Soundtrack.download`
-
-```python
-def download(
-    self,
-    output_dir: Path,
-    formats: Optional[List[str]] = None,
-    download_images: bool = False,
-    verbose: bool = False
-) -> bool:
-    """Download all tracks and optional album images.
-
-    Args:
-        output_dir: Destination directory for files.
-        formats: List of preferred audio extensions (e.g., ['flac', 'mp3']); defaults to all.
-        download_images: If True, also download cover art and other images.
-        verbose: If True, print per-file progress and retry messages.
-
-    Returns:
-        True if all requested files succeeded, False otherwise.
-
-    Raises:
-        InvalidFormatError: If none of the requested audio formats are available.
-        OSError: If the output directory cannot be created.
-    """
-```
-
-#### `Song` and `AudioFile`
-
-* Use `Song` when you need per-track metadata:
-
-  ```python
-  for song in ost.songs:
-      print(song.name, [f.extension for f in song.files])
-  ```
-* Use `AudioFile` to inspect or download individual URLs:
-
-  ```python
-  file = ost.songs[0].files[0]
-  file.download(Path("myfile.mp3"))
-  ```
-  
-## Never used Python before?
-
-If you’ve never used Python or the command line before, these steps will walk you through running the KHInsider Downloader on **Windows**, **macOS**, or **Linux**.
-
-### 1. Install Python
-
-- **Windows**  
-  1. Go to https://www.python.org/downloads/windows/  
-  2. Download the latest **“Windows installer (64-bit)”**.  
-  3. Run the installer, **check “Add Python to PATH”**, then click **Install Now**.
-
-- **macOS**  
-  1. Open **Terminal** (Finder → Applications → Utilities → Terminal).  
-  2. Check if Python is already installed:
-     ```bash
-     python3 --version
-     ```
-  3. If it’s not installed or you need a newer version, install via [Homebrew](https://brew.sh/):
-     ```bash
-     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-     brew install python
-     ```
-
-- **Linux**  
-  1. Open your terminal.  
-  2. Update your package list and install Python 3 and pip:
-     ```bash
-     # Debian/Ubuntu
-     sudo apt update && sudo apt install python3 python3-pip
-     
-     # Fedora
-     sudo dnf install python3 python3-pip
-     
-     # Arch
-     sudo pacman -S python python-pip
-     ```
-
-### 2. Open the Command Line / Terminal
-
-- **Windows**: Press Win+R, type `cmd`, and press Enter.  
-- **macOS**: Finder → Applications → Utilities → **Terminal**.  
-- **Linux**: Your desktop’s **Terminal** app (often Ctrl+Alt+T).
-
-### 3. Download the KHInsider Script
-
-1. In your terminal, choose (or create) a folder where you want the tool to live. For example:
-   ```bash
-   cd ~/Downloads
-   mkdir khinsider-tool && cd khinsider-tool
-    ````
-
-2. Clone the repository:
-
-   ```bash
-   git clone https://github.com/obskyr/khinsider.git
-   cd khinsider
-   ```
-
-> **No Git?**
->
-> * **Windows/macOS**: Install from [https://git-scm.com/downloads](https://git-scm.com/downloads)
-> * **Linux**: `sudo apt install git` (or your distro’s equivalent)
-
-### 4. Install Dependencies
-
-Once inside the `khinsider` folder, run:
+Auto-install is on by default. To install manually instead:
 
 ```bash
-pip install --user -r requirements.txt
+pip install requests beautifulsoup4
 ```
 
-* The `--user` flag installs packages just for your user account (no need for administrator rights).
-
-### 5. Make the Script Executable (macOS/Linux)
-
-On **macOS** or **Linux**, you may need to give the script permission to run:
+Disable auto-install:
 
 ```bash
-chmod +x khinsider.py
+export KHI_NO_AUTO_INSTALL=1    # Power users/etc.
 ```
-
-> **Windows users:** You can skip `chmod`; Windows will use the file association.
-
-### 6. Run the Downloader
-
-In the same terminal window, use:
-
-```bash
-# Basic usage: replace <album-id-or-url> with the soundtrack you want
-python3 khinsider.py <album-id-or-url>
-```
-
-Or, if you added the tool to your PATH (see Installation instructions above):
-
-```bash
-khinsider.py <album-id-or-url>
-```
-
-#### Examples
-
-* **Download in FLAC only**:
-
-  ```bash
-  python3 khinsider.py aquaplus-vocal-collection-vol.4 -f flac
-  ```
-* **Download FLAC or MP3 + album images + verbose output**:
-
-  ```bash
-  python3 khinsider.py minecraft -f flac,mp3 -i -v
-  ```
 
 ---
-
-That’s it! If you hit any errors, double-check that:
-
-1. **Python 3.7+** is installed and on your PATH.
-2. You ran `pip install -r requirements.txt`.
-3. You’re in the right folder (`cd khinsider`).
 
 ## Support
 
-* Report issues and request features on [GitHub Issues](https://github.com/obskyr/khinsider/issues).
-* Reach out on Twitter [@obskyr](https://twitter.com/obskyr) or by email at [contact@obskyr.io](mailto:contact@obskyr.io).
+* Issues: [https://github.com/obskyr/khinsider/issues](https://github.com/obskyr/khinsider/issues)

--- a/readme.md
+++ b/readme.md
@@ -1,78 +1,176 @@
-# khinsider.py
+# KHInsider Downloader
 
-`khinsider.py` is a [Python](https://www.python.org/) interface and script for getting [khinsider](http://downloads.khinsider.com/) soundtracks. It makes khinsider mass downloads a breeze. It's easy to use - check it!
+A command-line and library interface for mass-downloading full game soundtracks (and optional album images) from [KHInsider](https://downloads.khinsider.com/). Built for Python 3 with best practices, Google-style documentation, and robust error handling.
 
-From the command line (i.e. regular usage):
+---
 
-```cmd
-khinsider.py jumping-flash
+## Features
+
+- Download entire soundtrack albums by ID or URL
+- Support for multiple audio formats (FLAC, MP3, etc.) with user-defined priority
+- **New**: Optional download of album images (cover art, booklet scans)
+- Automatic creation of sanitized output directories
+- HTTP connection reuse for performance
+- Retries on transient network failures
+- Comprehensive error reporting and exit codes
+
+---
+
+## Requirements
+
+- Python 3.7+
+- [requests](https://pypi.org/project/requests) 2.31.0 or later (< 3.0.0)
+- [beautifulsoup4](https://pypi.org/project/beautifulsoup4) 4.12.0 or later (< 5.0.0)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+````
+
+---
+
+## Installation
+
+Clone the repository or download the latest release ZIP:
+
+```bash
+git clone https://github.com/obskyr/khinsider.git
+cd khinsider
 ```
 
-As an import (for when you're programming):
+Ensure the script is executable:
 
-```python
-import khinsider
-khinsider.download('jumping-flash')
-# And bam, you've got the Jumping Flash soundtrack!
+```bash
+chmod +x khinsider.py
 ```
 
-For anime music, [check out `thehylia.py`](https://github.com/obskyr/thehylia).
+Optionally, install into your `$PATH`:
 
-Carefully put together by [@obskyr](http://twitter.com/obskyr)!
+```bash
+pip install .
+```
 
-### **[Download it here!](https://github.com/obskyr/khinsider/archive/master.zip)**
+---
 
 ## Usage
 
-Just run `khinsider.py` from the command line with the sole parameter being the soundtrack you want to download. You can either use the soundtrack's ID, or simply copy its entire URL. Easy!
+### Command-Line Interface
 
-If you want, you can also add another parameter as the output folder, but that's optional.
-
-You can also download other file formats (if available), like FLAC or OGG, as following:
-
-```cmd
-khinsider.py --format flac mother-3
+```bash
+khinsider.py <album-id-or-url> [OPTIONS]
 ```
 
-If you don't want to go to the actual site to look for soundtracks, you can also just type a search term as the first parameter(s), and provided it's not a valid soundtrack, `khinsider.py` will give you a list of soundtracks matching that term.
+**Positional arguments**
 
-You're going to need [Python](https://www.python.org/downloads/) (if you don't know which version to get, choose the latest version of Python 3 - `khinsider.py` works with both 2 and 3), so install that (and [add it to your path](http://superuser.com/a/143121)) if you haven't already.
+* `<album-id-or-url>`
+  The soundtrack identifier (e.g. `kh2fm-soundtrack`) or full URL.
 
-You will also need to have [pip](https://pip.readthedocs.org/en/latest/installing.html) installed (if you have Python 3, it is most likely already installed - otherwise, download `get-pip.py` and run it) if you don't already have [requests](https://pypi.python.org/pypi/requests) and [Beautiful Soup 4](https://pypi.python.org/pypi/beautifulsoup4). The first time `khinsider.py` runs, it will install these two for you.
+**Options**
 
-For more detailed information, try running `khinsider.py --help`!
+* `-o, --output DIR`
+  Output directory (default: sanitized album name).
+* `-f, --format FORMATS`
+  Comma-separated list of preferred audio formats, in priority order (e.g. `flac,mp3`).
+* `-i, --images`
+  Download album images (cover, booklet, etc.) in addition to audio.
+* `-v, --verbose`
+  Show detailed progress and retry messages.
+* `-h, --help`
+  Show usage information and exit.
 
-## As a module
+**Exit codes**
 
-`khinsider.py` requires two non-standard modules: [requests](https://pypi.python.org/pypi/requests) and [beautifulsoup4](https://pypi.python.org/pypi/beautifulsoup4). Just run a `pip install` on them (with [pip](https://pip.readthedocs.org/en/latest/installing.html)), or just run `khinsider.py` on its own once and it'll install them for you.
+* `0` All files downloaded successfully
+* `1` Completed with errors or unexpected exception
+* `2` Invalid arguments or help request
 
-Here are the main functions you will be using:
+#### Examples
 
-### `khinsider.download(soundtrackName[, path="", makeDirs=True, formatOrder=None, verbose=False])`
+Download the **Aquaplus Vocal Collection Vol. 4** in FLAC:
 
-Download the soundtrack `soundtrackName`. This should be the name the soundtrack uses at the end of its album URL.
+```bash
+khinsider.py aquaplus-vocal-collection-vol.4 -f flac
+```
 
-If `path` is specified, the soundtrack files will be downloaded to the directory that path points to.
+Download **KH3 OST** in FLAC or MP3, plus album images, with verbose output:
 
-If `makeDirs` is `True`, the directory will be created if it doesn't exist.
+```bash
+khinsider.py kh3-ost -f flac,mp3 -i -v
+```
 
-You can specify `formatOrder` to download soundtracks in specific formats. `formatOrder=['flac', 'mp3']`, for example, will download FLACs if available, and MP3s if not.
+---
 
-If `verbose` is `True`, it will print progress as it is downloading.
+### Library Interface
 
-### `khinsider.search(term)`
+Use `khinsider.py` as a module in your own Python code:
 
-Search khinsider for `term`. Return a list of `Soundtrack`s matching the search term. You can then access `soundtrack.id` or `soundtrack.url`.
+```python
+from pathlib import Path
+import khinsider
 
-### More
+# Download audio only, default formats
+khinsider.download(
+    soundtrack_id="jumping-flash",
+    output_dir=Path("Jumping Flash OST"),
+    formats=None,
+    download_images=False,
+    verbose=True,
+)
 
-There's a lot more detail to the API - more than would be sensible to write here. If you want to use `khinsider.py` as a module in a more advanced capacity, have a look at the `Soundtrack`, `Song`, and `File` objects in the source code! They're documented properly there for your reading pleasure.
+# Download MP3s and images
+khinsider.download(
+    soundtrack_id="mother-3",
+    output_dir=Path("Mother 3 Soundtrack"),
+    formats=["mp3"],
+    download_images=True,
+    verbose=False,
+)
+```
 
-# Talk to me!
+#### API
 
-You can easily get to me in these ways:
+```python
+def download(
+    soundtrack_id: str,
+    output_dir: Path,
+    formats: Optional[List[str]] = None,
+    download_images: bool = False,
+    verbose: bool = False
+) -> bool:
+    """Download a KHInsider soundtrack and optional images.
 
-* [@obskyr](http://twitter.com/obskyr/) on Twitter!
-* [E-mail](mailto:powpowd@gmail.com) me!
+    Args:
+        soundtrack_id: ID or URL segment of the album.
+        output_dir: Directory to save files into.
+        formats: Preferred audio formats in descending priority.
+        download_images: If True, also download album images.
+        verbose: If True, print progress to stdout.
 
-I'd love to hear it if you like `khinsider.py`! If there's a problem, or you'd like a new feature, submit an issue here on GitHub.
+    Returns:
+        True if all requested files succeeded, False otherwise.
+    """
+```
+
+---
+
+## Contributing
+
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
+
+* Bug reports and feature requests
+* Coding style and testing conventions
+* Pull request process
+
+---
+
+## License
+
+This project is licensed under the **MIT License**. See [LICENSE](LICENSE) for details.
+
+---
+
+## Support
+
+* Report issues and request features on [GitHub Issues](https://github.com/obskyr/khinsider/issues).
+* Reach out on Twitter [@obskyr](https://twitter.com/obskyr) or by email at [contact@obskyr.io](mailto:contact@obskyr.io).

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # KHInsider Downloader
 
-A command-line and library interface for mass-downloading full game soundtracks (and optional album images) from [KHInsider](https://downloads.khinsider.com/). Built for Python 3 with best practices, Google-style documentation, and robust error handling.
+A command-line and library interface for mass-downloading full game soundtracks (and optional album images) from [KHInsider](https://downloads.khinsider.com/). Built for Python 3.
 
 ---
 
@@ -19,8 +19,8 @@ A command-line and library interface for mass-downloading full game soundtracks 
 ## Requirements
 
 - Python 3.7+
-- [requests](https://pypi.org/project/requests) 2.31.0 or later (< 3.0.0)
-- [beautifulsoup4](https://pypi.org/project/beautifulsoup4) 4.12.0 or later (< 5.0.0)
+- [requests](https://pypi.org/project/requests) 2.31.0 or later
+- [beautifulsoup4](https://pypi.org/project/beautifulsoup4) 4.12.0 or later
 
 Install dependencies with:
 

--- a/readme.md
+++ b/readme.md
@@ -103,34 +103,44 @@ khinsider.py kh3-ost -f flac,mp3 -i -v
 
 ### Library Interface
 
-Use `khinsider.py` as a module in your own Python code:
+Use the core classes directly in your own code:
 
 ```python
 from pathlib import Path
-import khinsider
+import requests
+from khinsider import Soundtrack
 
-# Download audio only, default formats
-khinsider.download(
-    soundtrack_id="jumping-flash",
+# Create an HTTP session
+session = requests.Session()
+
+# Instantiate a Soundtrack by its ID (or URL segment)
+ost = Soundtrack("jumping-flash", session)
+
+# Download audio only (default formats)
+ost.download(
     output_dir=Path("Jumping Flash OST"),
     formats=None,
     download_images=False,
     verbose=True,
 )
 
-# Download MP3s and images
-khinsider.download(
-    soundtrack_id="mother-3",
-    output_dir=Path("Mother 3 Soundtrack"),
+# Download only MP3s plus album images
+ost.download(
+    output_dir=Path("Mother 3 OST"),
     formats=["mp3"],
     download_images=True,
     verbose=False,
 )
-```
+````
 
-#### API
+If you prefer a single‐function entry point, add this to your module:
 
 ```python
+import requests
+from khinsider import Soundtrack
+from pathlib import Path
+from typing import List, Optional
+
 def download(
     soundtrack_id: str,
     output_dir: Path,
@@ -138,21 +148,72 @@ def download(
     download_images: bool = False,
     verbose: bool = False
 ) -> bool:
-    """Download a KHInsider soundtrack and optional images.
+    """Convenience wrapper around Soundtrack.download()."""
+    session = requests.Session()
+    ost = Soundtrack(soundtrack_id, session)
+    return ost.download(output_dir, formats, download_images, verbose)
+```
 
-    Args:
-        soundtrack_id: ID or URL segment of the album.
-        output_dir: Directory to save files into.
-        formats: Preferred audio formats in descending priority.
-        download_images: If True, also download album images.
-        verbose: If True, print progress to stdout.
+Then call:
 
-    Returns:
-        True if all requested files succeeded, False otherwise.
-    """
+```python
+import khinsider
+from pathlib import Path
+
+khinsider.download(
+    "jumping-flash",
+    Path("Jumping Flash OST"),
+    formats=None,
+    download_images=False,
+    verbose=True,
+)
 ```
 
 ---
+
+### API
+
+#### `Soundtrack.download`
+
+```python
+def download(
+    self,
+    output_dir: Path,
+    formats: Optional[List[str]] = None,
+    download_images: bool = False,
+    verbose: bool = False
+) -> bool:
+    """Download all tracks and optional album images.
+
+    Args:
+        output_dir: Destination directory for files.
+        formats: List of preferred audio extensions (e.g., ['flac', 'mp3']); defaults to all.
+        download_images: If True, also download cover art and other images.
+        verbose: If True, print per-file progress and retry messages.
+
+    Returns:
+        True if all requested files succeeded, False otherwise.
+
+    Raises:
+        InvalidFormatError: If none of the requested audio formats are available.
+        OSError: If the output directory cannot be created.
+    """
+```
+
+#### `Song` and `AudioFile`
+
+* Use `Song` when you need per-track metadata:
+
+  ```python
+  for song in ost.songs:
+      print(song.name, [f.extension for f in song.files])
+  ```
+* Use `AudioFile` to inspect or download individual URLs:
+
+  ```python
+  file = ost.songs[0].files[0]
+  file.download(Path("myfile.mp3"))
+  ```
 
 ## Support
 

--- a/readme.md
+++ b/readme.md
@@ -95,10 +95,10 @@ Download the **Aquaplus Vocal Collection Vol. 4** in FLAC:
 khinsider.py aquaplus-vocal-collection-vol.4 -f flac
 ```
 
-Download **KH3 OST** in FLAC or MP3, plus album images, with verbose output:
+Download **Minecraft OST** in FLAC or MP3, plus album images, with verbose output:
 
 ```bash
-khinsider.py kh3-ost -f flac,mp3 -i -v
+khinsider.py minecraft -f flac,mp3 -i -v
 ```
 
 ---
@@ -325,7 +325,7 @@ khinsider.py <album-id-or-url>
 * **Download FLAC or MP3 + album images + verbose output**:
 
   ```bash
-  python3 khinsider.py kh3-ost -f flac,mp3 -i -v
+  python3 khinsider.py minecraft -f flac,mp3 -i -v
   ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A command-line and library interface for mass-downloading full game soundtracks (and optional album images) from [KHInsider](https://downloads.khinsider.com/). Built for Python 3.
 
+> **New to Python?** If you’ve never used Python before, [click here](#never-used-python-before) to get started.
+
 ---
 
 ## Features
@@ -214,6 +216,125 @@ def download(
   file = ost.songs[0].files[0]
   file.download(Path("myfile.mp3"))
   ```
+  
+## Never used Python before?
+
+If you’ve never used Python or the command line before, these steps will walk you through running the KHInsider Downloader on **Windows**, **macOS**, or **Linux**.
+
+### 1. Install Python
+
+- **Windows**  
+  1. Go to https://www.python.org/downloads/windows/  
+  2. Download the latest **“Windows installer (64-bit)”**.  
+  3. Run the installer, **check “Add Python to PATH”**, then click **Install Now**.
+
+- **macOS**  
+  1. Open **Terminal** (Finder → Applications → Utilities → Terminal).  
+  2. Check if Python is already installed:
+     ```bash
+     python3 --version
+     ```
+  3. If it’s not installed or you need a newer version, install via [Homebrew](https://brew.sh/):
+     ```bash
+     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+     brew install python
+     ```
+
+- **Linux**  
+  1. Open your terminal.  
+  2. Update your package list and install Python 3 and pip:
+     ```bash
+     # Debian/Ubuntu
+     sudo apt update && sudo apt install python3 python3-pip
+     
+     # Fedora
+     sudo dnf install python3 python3-pip
+     
+     # Arch
+     sudo pacman -S python python-pip
+     ```
+
+### 2. Open the Command Line / Terminal
+
+- **Windows**: Press Win+R, type `cmd`, and press Enter.  
+- **macOS**: Finder → Applications → Utilities → **Terminal**.  
+- **Linux**: Your desktop’s **Terminal** app (often Ctrl+Alt+T).
+
+### 3. Download the KHInsider Script
+
+1. In your terminal, choose (or create) a folder where you want the tool to live. For example:
+   ```bash
+   cd ~/Downloads
+   mkdir khinsider-tool && cd khinsider-tool
+    ````
+
+2. Clone the repository:
+
+   ```bash
+   git clone https://github.com/obskyr/khinsider.git
+   cd khinsider
+   ```
+
+> **No Git?**
+>
+> * **Windows/macOS**: Install from [https://git-scm.com/downloads](https://git-scm.com/downloads)
+> * **Linux**: `sudo apt install git` (or your distro’s equivalent)
+
+### 4. Install Dependencies
+
+Once inside the `khinsider` folder, run:
+
+```bash
+pip install --user -r requirements.txt
+```
+
+* The `--user` flag installs packages just for your user account (no need for administrator rights).
+
+### 5. Make the Script Executable (macOS/Linux)
+
+On **macOS** or **Linux**, you may need to give the script permission to run:
+
+```bash
+chmod +x khinsider.py
+```
+
+> **Windows users:** You can skip `chmod`; Windows will use the file association.
+
+### 6. Run the Downloader
+
+In the same terminal window, use:
+
+```bash
+# Basic usage: replace <album-id-or-url> with the soundtrack you want
+python3 khinsider.py <album-id-or-url>
+```
+
+Or, if you added the tool to your PATH (see Installation instructions above):
+
+```bash
+khinsider.py <album-id-or-url>
+```
+
+#### Examples
+
+* **Download in FLAC only**:
+
+  ```bash
+  python3 khinsider.py aquaplus-vocal-collection-vol.4 -f flac
+  ```
+* **Download FLAC or MP3 + album images + verbose output**:
+
+  ```bash
+  python3 khinsider.py kh3-ost -f flac,mp3 -i -v
+  ```
+
+---
+
+That’s it! If you hit any errors, double-check that:
+
+1. **Python 3.7+** is installed and on your PATH.
+2. You ran `pip install -r requirements.txt`.
+3. You’re in the right folder (`cd khinsider`).
 
 ## Support
 

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,16 @@
 
 `khinsider.py` is a [Python](https://www.python.org/) interface and script for getting [khinsider](http://downloads.khinsider.com/) soundtracks. It makes khinsider mass downloads a breeze. It's easy to use, check it!
 
-> **Zero-setup:** Just run the script, it auto-installs dependencies!
+> **Requires Python 3.9+**  
+> **Zero-setup:** Just run the script, it auto-installs dependencies!  
 > Set `KHI_NO_AUTO_INSTALL=1` to disable auto-install.
 
 ---
 
 ## Quick Start
 
+1) In your command line of choice, **Windows:** Command Prompt or PowerShell, **macOS:** Terminal, **Linux:** any terminal.
+2) In the **same folder as `khinsider.py`**:
 ```bash
 # Download by ID
 python khinsider.py plants-vs.-zombies
@@ -60,7 +63,7 @@ python khinsider.py <album-id-or-url> [options]
 
 ## “Never used Python before?”
 
-1. Install Python 3 from [https://www.python.org/downloads/](https://www.python.org/downloads/)
+1. Install the latest Python version from [https://www.python.org/downloads/](https://www.python.org/downloads/)
 2. Download this repo (or the single `khinsider.py` file)
 3. Run:
 

--- a/readme.md
+++ b/readme.md
@@ -154,22 +154,6 @@ def download(
 
 ---
 
-## Contributing
-
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
-
-* Bug reports and feature requests
-* Coding style and testing conventions
-* Pull request process
-
----
-
-## License
-
-This project is licensed under the **MIT License**. See [LICENSE](LICENSE) for details.
-
----
-
 ## Support
 
 * Report issues and request features on [GitHub Issues](https://github.com/obskyr/khinsider/issues).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# requirements.txt — KHInsider downloader
+
+# HTTP client
+requests>=2.31.0,<3.0.0
+
+# HTML parsing
+beautifulsoup4>=4.12.0,<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-# requirements.txt — KHInsider downloader
-
-# HTTP client
-requests>=2.31.0,<3.0.0
-
-# HTML parsing
-beautifulsoup4>=4.12.0,<5.0.0


### PR DESCRIPTION
Migrate the codebase to Python 3.7+, remove all Python 2 compatibility shims, and modernize core logic and documentation.

- Removed __future__ imports, unicodePrint(), lazyProperty, and other Py2 workarounds
- Replaced os.path with pathlib.Path, switches to f-strings and inline type hints
- Centralized HTML fetching into get_soup() using contextlib.suppress
- Refactored into AudioFile, Song, and Soundtrack classes
- Made image downloading optional
- Updated Google-style docstrings, CLI help text, README.md, and added requirements.txt

Strip surrounding quotes from the output path argument before directory creation -> Fixes https://github.com/obskyr/khinsider/issues/55
Drop reliance on a missing #pageContent container and parse directly from the full soup -> Fixes https://github.com/obskyr/khinsider/issues/71
Sanitize and normalize output paths with pathlib.Path.mkdir(parents=True), removing illegal Windows characters (e.g., colons) -> Fixes https://github.com/obskyr/khinsider/issues/72
Switched to chunked, streaming downloads with a 30 s timeout for large files -> Fixes https://github.com/obskyr/khinsider/issues/75
Detect “No such album” via a text search instead of relying on find('p').string -> Fixes https://github.com/obskyr/khinsider/issues/81
Extract the album ID from a full KHInsider URL before CLI parsing -> Fixes https://github.com/obskyr/khinsider/issues/82
Updated README with clear, step-by-step installation and usage instructions for beginners -> Fixes https://github.com/obskyr/khinsider/issues/85
Ensure the output directory (and any missing parent folders) is created before writing each file -> Fixes https://github.com/obskyr/khinsider/issues/89
Guard against a missing `songlist` table before iterating rows -> Fixes https://github.com/obskyr/khinsider/issues/90
Added requirements.txt -> Fixes https://github.com/obskyr/khinsider/issues/95
Removed the Python 2 unicodePrint wrapper and now use native print with UTF-8 support -> Fixes https://github.com/obskyr/khinsider/issues/96
Guard against a missing `songlist` table before iterating rows -> Fixes https://github.com/obskyr/khinsider/issues/100
Includes a user agent string spoofer to circumvent their new anti-web-scraping. Still fully robots.txt compliant. ->Fixes https://github.com/obskyr/khinsider/issues/100 | Fixes https://github.com/obskyr/khinsider/issues/101 | Fixes https://github.com/obskyr/khinsider/issues/104 | Fixes https://github.com/obskyr/khinsider/issues/105